### PR TITLE
grub: fix mismatched typedefs

### DIFF
--- a/src/endless/grub/grub.h
+++ b/src/endless/grub/grub.h
@@ -22,11 +22,13 @@
 #include <inttypes.h>
 
 
+typedef uint8_t grub_uint8_t;
 typedef uint16_t grub_uint16_t;
 typedef uint32_t grub_uint32_t;
 typedef uint64_t grub_uint64_t;
 
-typedef grub_uint64_t grub_size_t;
+typedef size_t grub_size_t;
+typedef SSIZE_T grub_ssize_t;
 typedef int grub_err_t;
 
 /* The type for representing a disk block address.  */

--- a/src/endless/grub/reed_solomon.c
+++ b/src/endless/grub/reed_solomon.c
@@ -19,6 +19,8 @@
  /* Disable: warning C4018: signed/unsigned mismatch */
 #pragma warning(disable:4018)
 
+#include "reed_solomon.h"
+
 
 #include <stdio.h>
 #include <string.h>
@@ -28,10 +30,6 @@
 #define grub_memcpy memcpy
 
 #include <assert.h>
-
-typedef unsigned int grub_size_t;
-typedef unsigned char grub_uint8_t;
-typedef long grub_ssize_t;
 
 #define SECTOR_SIZE 512
 #define MAX_BLOCK_SIZE (200 * SECTOR_SIZE)

--- a/src/endless/grub/reed_solomon.h
+++ b/src/endless/grub/reed_solomon.h
@@ -19,6 +19,8 @@
 #ifndef GRUB_REED_SOLOMON_HEADER
 #define GRUB_REED_SOLOMON_HEADER	1
 
+#include "grub.h"
+
 void
 grub_reed_solomon_add_redundancy (void *buffer, grub_size_t data_size,
 				  grub_size_t redundancy);


### PR DESCRIPTION
I suspect this is why the 'redundancy' parameter is non-zero in the
caller but zero here.
