### PR TITLE
Add <compatibility> section to embedded manifest

### DIFF
--- a/src/endless/EndlessUsbTool.manifest
+++ b/src/endless/EndlessUsbTool.manifest
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/src/endless/EndlessUsbTool.vcxproj
+++ b/src/endless/EndlessUsbTool.vcxproj
@@ -504,6 +504,9 @@
     <Image Include="res\images\wizard_page_indicator_selected.png" />
   </ItemGroup>
   <ItemGroup>
+    <Manifest Include="EndlessUsbTool.manifest" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\bled\.msvc\bled.vcxproj">
       <Project>{fb6d52d4-a2f8-c358-db85-bbcaecfddd7d}</Project>
     </ProjectReference>

--- a/src/endless/EndlessUsbTool.vcxproj.filters
+++ b/src/endless/EndlessUsbTool.vcxproj.filters
@@ -286,6 +286,11 @@
     </Image>
   </ItemGroup>
   <ItemGroup>
+    <Manifest Include="EndlessUsbTool.manifest">
+      <Filter>Resource Files</Filter>
+    </Manifest>
+  </ItemGroup>
+  <ItemGroup>
     <Font Include="res\fonts\ttf\Lato-Black.ttf">
       <Filter>Resource Files\Fonts</Filter>
     </Font>


### PR DESCRIPTION
I believe this will fix Windows 7 complaining that “This program might not have installed correctly” when the executable contains the word “installer”. I don't have a Windows 7 machine to test with though. The VM is downloading…

I have checked in Task Manager, though. Previous versions are reported as running in a Vista context despite being on Windows 8.1 or 10; now they are reported as running in an 8.1 context on 8.1, and a 10 context on 10.

This also has the nice side-effect that Windows 10 is no longer reported as being Windows 8.1 in the debug logs.

https://phabricator.endlessm.com/T13248
