### PR TITLE
report Windows version as a custom dimension for Google Analytics

### DIFF
--- a/src/endless/Analytics.cpp
+++ b/src/endless/Analytics.cpp
@@ -66,6 +66,7 @@ Analytics::Analytics()
 	m_trackingId = CString(_T(TRACKING_ID));
 	loadUuid(m_clientId);
 	m_language = "en-US";
+	urlEncode(CString(WindowsVersionStr), m_windowsVersion);
 	m_workerThread = AfxBeginThread(threadSendRequest, NULL);
 }
 
@@ -199,5 +200,6 @@ void Analytics::urlEncode(const CString &in, CString &out)
 
 void Analytics::prefixId(CString &id)
 {
-	id.Format(_T("v=1&tid=%s&cid=%s&an=Endless%%20Installer&av=%s&ul=%s&"), m_trackingId, m_clientId, _T(RELEASE_VER_STR), m_language);
+	id.Format(_T("v=1&tid=%s&cid=%s&an=Endless%%20Installer&av=%s&ul=%s&cd1=%s&"),
+		m_trackingId, m_clientId, _T(RELEASE_VER_STR), m_language, m_windowsVersion);
 }

--- a/src/endless/Analytics.h
+++ b/src/endless/Analytics.h
@@ -27,5 +27,6 @@ private:
 	CString m_clientId;
 	BOOL m_disabled;
 	CString m_language;
+	CString m_windowsVersion;
 	CWinThread *m_workerThread;
 };


### PR DESCRIPTION
Google Analytics derives the OS version from the User Agent which has to be an
actual end-user browser. They don't have a way for apps using the measurement
API to fill in the OS dimension, so they instead suggest using a custom
dimension:
https://groups.google.com/d/msg/google-analytics-measurement-protocol/5S4xEAxd1_o/N4jWCtXmCrEJ
