### PR TITLE
fix for detecting windows MBRs with localised messages

### DIFF
--- a/src/ms-sys/br.c
+++ b/src/ms-sys/br.c
@@ -117,7 +117,7 @@ int is_2000_mbr(FILE *fp)
    #include "mbr_2000.h"
 
    return
-      contains_data(fp, 0x0, mbr_2000_0x0, sizeof(mbr_2000_0x0)) &&
+      contains_data(fp, 0x0, mbr_2000_0x0, MBR_2000_LANG_INDEP_LEN) &&
       is_br(fp);
 } /* is_2000_mbr */
 
@@ -126,7 +126,7 @@ int is_vista_mbr(FILE *fp)
    #include "mbr_vista.h"
 
    return
-      contains_data(fp, 0x0, mbr_vista_0x0, sizeof(mbr_vista_0x0)) &&
+      contains_data(fp, 0x0, mbr_vista_0x0, MBR_VISTA_LANG_INDEP_LEN) &&
       is_br(fp);
 } /* is_vista_mbr */
 
@@ -135,7 +135,7 @@ int is_win7_mbr(FILE *fp)
    #include "mbr_win7.h"
 
    return
-      contains_data(fp, 0x0, mbr_win7_0x0, sizeof(mbr_win7_0x0)) &&
+      contains_data(fp, 0x0, mbr_win7_0x0, MBR_WIN7_LANG_INDEP_LEN) &&
       is_br(fp);
 } /* is_win7_mbr */
 

--- a/src/ms-sys/inc/mbr_2000.h
+++ b/src/ms-sys/inc/mbr_2000.h
@@ -1,7 +1,9 @@
 /* First 446 bytes of MBR from Windows 2000, XP and 2003 */
 /* This is English version. Bytes 0x12c onwards vary with language. */
-/* Last two bytes 1b6 and 1b7 point to language-specific messages.  */
+/* Last three bytes 1b5-1b7 point to language-specific messages.    */
 /* Support of other languages is an exercise for the reader!        */
+/* see: http://thestarman.pcministry.com/asm/mbr/Win2kmbr.htm       */
+#define MBR_2000_LANG_INDEP_LEN 0x12c
 unsigned char mbr_2000_0x0[] = {
   0x33, 0xc0, 0x8e, 0xd0, 0xbc, 0x00, 0x7c, 0xfb, 0x50, 0x07, 0x50, 0x1f,
   0xfc, 0xbe, 0x1b, 0x7c, 0xbf, 0x1b, 0x06, 0x50, 0x57, 0xb9, 0xe5, 0x01,

--- a/src/ms-sys/inc/mbr_vista.h
+++ b/src/ms-sys/inc/mbr_vista.h
@@ -1,7 +1,9 @@
 /* First 446 bytes of MBR from Windows Vista */
-/* This is English version. Bytes 0x12c onwards vary with language. */
-/* Last two bytes 1b6 and 1b7 point to language-specific messages.  */
+/* This is English version. Bytes 0x162 onwards vary with language. */
+/* Last three bytes 1b5-1b7 point to language-specific messages.    */
 /* Support of other languages is an exercise for the reader!        */
+/* see: http://thestarman.pcministry.com/asm/mbr/VistaMBR.htm       */
+#define MBR_VISTA_LANG_INDEP_LEN 0x162
 unsigned char mbr_vista_0x0[] = {
 0x33, 0xc0, 0x8e, 0xd0, 0xbc, 0x00, 0x7c, 0x8e, 0xc0, 0x8e, 0xd8, 0xbe,
 0x00, 0x7c, 0xbf, 0x00, 0x06, 0xb9, 0x00, 0x02, 0xfc, 0xf3, 0xa4, 0x50,

--- a/src/ms-sys/inc/mbr_win7.h
+++ b/src/ms-sys/inc/mbr_win7.h
@@ -1,7 +1,9 @@
 /* First 446 bytes of MBR from Windows 7 */
-/* This is English version. Bytes 0x12c onwards vary with language. */
-/* Last two bytes 1b6 and 1b7 point to language-specific messages.  */
+/* This is English version. Bytes 0x163 onwards vary with language. */
+/* Last three bytes 1b5-1b7 point to language-specific messages.    */
 /* Support of other languages is an exercise for the reader!        */
+/* see: http://thestarman.pcministry.com/asm/mbr/W7MBR.htm          */
+#define MBR_WIN7_LANG_INDEP_LEN 0x163
 unsigned char mbr_win7_0x0[] = {
   0x33, 0xc0, 0x8e, 0xd0, 0xbc, 0x00, 0x7c, 0x8e, 0xc0, 0x8e, 0xd8, 0xbe,
   0x00, 0x7c, 0xbf, 0x00, 0x06, 0xb9, 0x00, 0x02, 0xfc, 0xf3, 0xa4, 0x50,


### PR DESCRIPTION
Windows MBRs contain localised strings which mean the bytes between the
executable code and the disk signature / partition table can change depending
on locale. This patch adds lengths to reflect the offsets which are the same
for every locale, and only compares these lengths when detecting existing
Windows MBRs.

https://phabricator.endlessm.com/T13457
