### PR TITLE
add /forcembr flag to skip checking for Windows MBR

### DIFF
--- a/src/endless/EndlessUsbTool.cpp
+++ b/src/endless/EndlessUsbTool.cpp
@@ -25,18 +25,22 @@ class CAppCmdLineInfo : public CCommandLineInfo
 {
 public:
     CAppCmdLineInfo(void) :
-        logDebugInfo(false) {}
+        logDebugInfo(false), forceMbr(false)
+    {}
 
     virtual void ParseParam(const TCHAR* pszParam, BOOL bFlag, BOOL bLast)
     {
         if (0 == _tcscmp(_T("debug"), pszParam)) {
             logDebugInfo = true;
+        } else if (0 == _tcscmp(_T("forcembr"), pszParam)) {
+            forceMbr = true;
         } else {
             CCommandLineInfo::ParseParam(pszParam, bFlag, bLast);
         }
     }
 
     bool logDebugInfo;
+    bool forceMbr;
 };
 
 
@@ -48,6 +52,7 @@ END_MESSAGE_MAP()
 
 CString CEndlessUsbToolApp::m_appDir = L"";
 bool CEndlessUsbToolApp::m_enableLogDebugging = false;
+bool CEndlessUsbToolApp::m_enableOverwriteMbr = false;
 CFile CEndlessUsbToolApp::m_logFile;
 
 // CEndlessUsbToolApp construction
@@ -109,6 +114,8 @@ BOOL CEndlessUsbToolApp::InitInstance()
     // check command line parameters;
     CAppCmdLineInfo commandLineInfo;
     ParseCommandLine(commandLineInfo);
+
+	m_enableOverwriteMbr = commandLineInfo.forceMbr;
 
 	//m_enableLogDebugging = commandLineInfo.logDebugInfo;
 	m_enableLogDebugging = true;

--- a/src/endless/EndlessUsbTool.h
+++ b/src/endless/EndlessUsbTool.h
@@ -27,6 +27,7 @@ public:
 
 	static CString m_appDir;
 	static bool m_enableLogDebugging;
+	static bool m_enableOverwriteMbr;
 
 	static void Log(const char *logMessage);
 

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -4818,7 +4818,9 @@ bool CEndlessUsbToolDlg::WriteMBRAndSBRToWinDrive(CEndlessUsbToolDlg *dlg, const
 
 	// Make sure there already is a Windows MBR on this disk
 	fake_fd._handle = (char*)hPhysical;
-	if (!IsWindowsMBR(fp, systemDriveLetter)) {
+	if (CEndlessUsbToolApp::m_enableOverwriteMbr) {
+		uprintf("Not checking for Windows MBRs as /forcembr is enabled.");
+	} else if (!IsWindowsMBR(fp, systemDriveLetter)) {
 		uprintf("Error: no Windows MBR detected, unsupported configuration.");
 		dlg->m_lastErrorCause = ErrorCause_t::ErrorCauseNonWindowsMBR;
 		goto error;


### PR DESCRIPTION
We found some Samsung recovery partition on a Windows 7 Home laptop which
prevents the installer from proceeding. I don't imagine Samsung shipped a lot
of Win 7 laptops in LatAm, so now that we know it's not a standard Windows MBR,
I don't think it's worth us trying to chase after these Samsung MBRs with a
whitelist. Here's an option which lets the install proceed, as a customer
support option.

https://phabricator.endlessm.com/T13459
