### PR TITLE
Show error message for BitLocker/32-bit systems

### DIFF
--- a/src/endless/res/EndlessUsbTool.htm
+++ b/src/endless/res/EndlessUsbTool.htm
@@ -23,7 +23,7 @@
                         <div id="DualBootContentLogo"><div id="DualBootContentLogoImage"></div></div>
                         <div id="DualBootContentTitle">Download and Install Endless on this PC</div>
                         <div id="DualBootContentDescription">Each time you start your PC, you will be able to choose between Endless and Windows. Your apps and files on Windows will not be affected.</div>
-                        <div class="Button ButtonBlue ButtonDisabled" id="DualBootInstallButonC"><div id="DualBootInstallButon">Install Endless</div></div>
+                        <div class="Button ButtonBlue" id="DualBootInstallButonC"><div id="DualBootInstallButon">Install Endless</div></div>
                         <div id="DualBootRecommendation">At least 32 GB free on the system drive is recommended.</div>
                     </div>
 


### PR DESCRIPTION
This should reduce support queries asking "why is the button greyed out?".

I think we should move the "Is it NTFS?" and "Does it have a non-Windows MBR?" changes sooner, in future, but I guess you're working on detecting an already-installed Endless OS up-front, @raduancuta, so that will sort of deal with the non-Windows MBR case.
