### PR TITLE
Only log the first up-front error

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -1912,10 +1912,6 @@ HRESULT CEndlessUsbToolDlg::OnInstallDualBootClicked(IHTMLElement* pElement)
 		QueryAndDoUninstall(false);
 	} else if (!x64BitSupported) {
 		ErrorOccured(ErrorCauseNot64Bit);
-
-		/* ::ErrorOccured tracks the "main" cause; let's also track this other problem */
-		if (isBitLockerEnabled)
-			Analytics::instance()->exceptionTracking(ErrorCauseToStr(ErrorCauseBitLocker), FALSE);
 	} else if (isBitLockerEnabled) {
 		ErrorOccured(ErrorCauseBitLocker);
 	} else if (!isNtfsPartition) {


### PR DESCRIPTION
We could do the legwork to report up to four errors (32-bit CPU,
BitLocker enabled, C: is not NTFS, MBR is not GRUB) but I don't think
it's worth it. Some of them will be strongly correlated anyway (I think
C: not being NTFS will always imply a 32-bit CPU)…
