### PR TITLE
add EnsureUncompressed function to check/remove NTFS compression

### DIFF
--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -319,6 +319,7 @@ private:
 
 	static DWORD WINAPI SetupDualBoot(LPVOID param);
 
+	static bool EnsureUncompressed(const CString &filePath);
 	static bool ExtendImageFile(const CString &endlessImgPath, ULONGLONG selectedGigs);
 	static bool UnpackBootComponents(const CString &bootFilesPathGz, const CString &bootFilesPath);
 	static bool CopyMultipleItems(const CString &fromPath, const CString &toPath);


### PR DESCRIPTION
Call on C:\endless before proceeding with install.

https://phabricator.endlessm.com/T13779
