### PR TITLE
allow uninstall to succeed even if the EFI entries have gone

### DIFF
--- a/src/endless/EndlessUsbTool.cpp
+++ b/src/endless/EndlessUsbTool.cpp
@@ -25,7 +25,7 @@ class CAppCmdLineInfo : public CCommandLineInfo
 {
 public:
     CAppCmdLineInfo(void) :
-        logDebugInfo(false), forceMbr(false), ignoreEFIError(false)
+        logDebugInfo(false), forceMbr(false)
     {}
 
     virtual void ParseParam(const TCHAR* pszParam, BOOL bFlag, BOOL bLast)
@@ -34,8 +34,6 @@ public:
             logDebugInfo = true;
         } else if (0 == _tcscmp(_T("forcembr"), pszParam)) {
             forceMbr = true;
-        } else if (0 == _tcscmp(_T("ignoreefi"), pszParam)) {
-            ignoreEFIError = true;
         } else {
             CCommandLineInfo::ParseParam(pszParam, bFlag, bLast);
         }
@@ -43,7 +41,6 @@ public:
 
     bool logDebugInfo;
     bool forceMbr;
-    bool ignoreEFIError;
 };
 
 
@@ -57,7 +54,6 @@ CString CEndlessUsbToolApp::m_appDir = L"";
 CString CEndlessUsbToolApp::m_imageDir = L"";
 bool CEndlessUsbToolApp::m_enableLogDebugging = false;
 bool CEndlessUsbToolApp::m_enableOverwriteMbr = false;
-bool CEndlessUsbToolApp::m_enableIgnoreEFIError = false;
 CFile CEndlessUsbToolApp::m_logFile;
 
 // CEndlessUsbToolApp construction
@@ -128,7 +124,6 @@ BOOL CEndlessUsbToolApp::InitInstance()
     ParseCommandLine(commandLineInfo);
 
 	m_enableOverwriteMbr = commandLineInfo.forceMbr;
-	m_enableIgnoreEFIError = commandLineInfo.ignoreEFIError;
 
 	//m_enableLogDebugging = commandLineInfo.logDebugInfo;
 	m_enableLogDebugging = true;

--- a/src/endless/EndlessUsbTool.h
+++ b/src/endless/EndlessUsbTool.h
@@ -30,7 +30,6 @@ public:
 	static CString m_imageDir;
 	static bool m_enableLogDebugging;
 	static bool m_enableOverwriteMbr;
-	static bool m_enableIgnoreEFIError;
 
 	static void Log(const char *logMessage);
 	static CString TempFilePath(CString filename);

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -5721,11 +5721,7 @@ BOOL CEndlessUsbToolDlg::UninstallDualBoot(CEndlessUsbToolDlg *dlg)
 	} else { // remove EFI entry
 		CString windowsEspDriveLetter;
 		IFFALSE_PRINTERROR(EFIRequireNeededPrivileges(), "Error on EFIRequireNeededPrivileges.");
-		if (CEndlessUsbToolApp::m_enableIgnoreEFIError) {
-			IFFALSE_PRINTERROR(EFIRemoveEntry(ENDLESS_OS_NAME), "Error on EFIRemoveEntry, continuing with uninstall as ignore EFI error parameter was provided.");
-		} else {
-			IFFALSE_GOTOERROR(EFIRemoveEntry(ENDLESS_OS_NAME), "Error on EFIRemoveEntry");
-		}
+		IFFALSE_PRINTERROR(EFIRemoveEntry(ENDLESS_OS_NAME), "Error on EFIRemoveEntry, continuing with uninstall anyway.");
 
 		IFFALSE_GOTOERROR(MountESPFromDrive(hPhysical, &espMountLetter, systemDriveLetter), "Error on MountESPFromDrive");
 		windowsEspDriveLetter = UTF8ToCString(espMountLetter);

--- a/src/endless/UEFIBootSetup.cpp
+++ b/src/endless/UEFIBootSetup.cpp
@@ -468,6 +468,7 @@ error:
 bool EFIRemoveEntry(wchar_t *desc) {
 	wchar_t varname[9];
 	int target = -1;
+	bool result = true;
 
 	//print_entries();
 
@@ -476,7 +477,10 @@ bool EFIRemoveEntry(wchar_t *desc) {
 
 	swprintf(varname, sizeof(varname), UEFI_VAR_BOOT_ENTRY_FORMAT, target);
 	/* Writing a zero length variable deletes it */
-	IFFALSE_RETURN_VALUE(SetFirmwareEnvironmentVariable(varname, UEFI_BOOT_NAMESPACE, NULL, 0), "Error on SetFirmwareEnvironmentVariable", false);
+	if (!SetFirmwareEnvironmentVariable(varname, UEFI_BOOT_NAMESPACE, NULL, 0)) {
+		uprintf("Error on SetFirmwareEnvironmentVariable");
+		result = false;
+	}
 
 	/* Remove our entry from the boot order */
 	DWORD size = GetFirmwareEnvironmentVariable(UEFI_VAR_BOOTORDER, UEFI_BOOT_NAMESPACE, vardata, sizeof(vardata));
@@ -507,5 +511,5 @@ bool EFIRemoveEntry(wchar_t *desc) {
 
 	//print_entries();
 
-	return true;
+	return result;
 }


### PR DESCRIPTION
This branch makes the behaviour to ignore EFI errors on uninstallation the default, avoids looking for a new boot entry number when all we want to do is delete one, and separately attempts deleting the boot entry as well as removing our entry from the boot order, regardless of whether either operation fails.

https://phabricator.endlessm.com/T13653
