### PR TITLE
Bump minimum version for image boot support

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -5909,7 +5909,7 @@ bool CEndlessUsbToolDlg::ShouldUninstall()
 		|| IsUninstaller());
 }
 
-#define MIN_DATE_IMAGE_BOOT	L"160917"
+#define MIN_DATE_IMAGE_BOOT	L"161020"
 
 // Image boot means support for booting from endless/endless.img
 // on dual boot (ntfs) and combined USB (exfat)


### PR DESCRIPTION
161020-23mmss images were the earliest images with a fix for
https://phabricator.endlessm.com/T13743 – without which dual boot installs
will fail to boot after Windows defragments the drive. In particular, the
3.0.4 release has this bug.

To guard against the situation where people download a new copy of the
installer but still have the 3.0.4 release images kicking around, bump the
minimum version we believe to have image boot support.

This is technically wrong for two reasons:
- Images from earlier in the day on 2016-10-20 still have this bug -- but
  they were not published
- Some earlier images can be used for USB sticks -- but many are also
  affected by a GRUB bug triggered by fragmented files on exFAT, so this
  check will also catch those!
