### PR TITLE
SetupDualBoot: unset READONLY when using endless.img

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -4925,7 +4925,11 @@ DWORD WINAPI CEndlessUsbToolDlg::SetupDualBoot(LPVOID param)
 	CEndlessUsbToolDlg::ImageUnpackFileSize = dlg->m_selectedFileSize;
 	if (CSTRING_GET_LAST(dlg->m_localFile, '\\') == ENDLESS_IMG_FILE_NAME) {
 		BOOL result = CopyFileEx(dlg->m_localFile, endlessImgPath, CEndlessUsbToolDlg::CopyProgressRoutine, dlg, NULL, 0);
-		IFFALSE_GOTOERROR(result, "Copying live image failed/cancelled.");
+		IFFALSE_GOTOERROR(result, "Copying unpacked dual-boot image failed/cancelled.");
+
+		// Clear READONLY flag inherited from endless.img on live USB.
+		IFFALSE_PRINTERROR(SetFileAttributes(endlessImgPath, FILE_ATTRIBUTE_SYSTEM | FILE_ATTRIBUTE_HIDDEN),
+			"Failed to clear FILE_ATTRIBUTE_READONLY; ExtendImageFile will probably now fail");
 	} else {
 		// Unpack img file
 		bool unpackResult = dlg->UnpackFile(dlg->m_localFile, endlessImgPath, 0, ImageUnpackCallback, &dlg->m_cancelImageUnpack);


### PR DESCRIPTION
On a live USB, the pristine endless.img file has the READONLY flag set.
CopyFileEx propagates it to the installed c:\endless\endless.img. We
ultimately do want that file to be READONLY but first we need to extend
it, and opening it for writing fails if it has the READONLY flag.

We could call GetFileAttributes, mask out FILE_ATTRIBUTE_READONLY, and
then pass the result back to SetFileAttributes but I just don't think
that's necessary: we will later set exactly r|s|h on this file so there's
no harm in setting two of those at the same time as clearing r.

https://phabricator.endlessm.com/T12858
