### PR TITLE
fix handling of various download cancel/error paths

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -3435,7 +3435,7 @@ HRESULT CEndlessUsbToolDlg::OnInstallCancelClicked(IHTMLElement* pElement)
     }
 
     m_lastErrorCause = ErrorCause_t::ErrorCauseCancelled;
-    CancelRunningOperation();
+    CancelRunningOperation(true);
 
     return S_OK;
 }
@@ -4131,7 +4131,7 @@ void CEndlessUsbToolDlg::EnableHibernate(bool enable)
     SetThreadExecutionState(flags);
 }
 
-void CEndlessUsbToolDlg::CancelRunningOperation()
+void CEndlessUsbToolDlg::CancelRunningOperation(bool userCancel)
 {
     FUNCTION_ENTER;
 
@@ -4140,7 +4140,7 @@ void CEndlessUsbToolDlg::CancelRunningOperation()
 
     FormatStatus = FORMAT_STATUS_CANCEL;
     if (m_currentStep != OP_FLASHING_DEVICE) {
-        m_downloadManager.ClearExtraDownloadJobs(true);
+        m_downloadManager.ClearExtraDownloadJobs(userCancel);
         PostMessage(WM_FINISHED_ALL_OPERATIONS, (WPARAM)FALSE, 0);
     }
 }

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -1239,16 +1239,19 @@ LRESULT CEndlessUsbToolDlg::WindowProc(UINT message, WPARAM wParam, LPARAM lPara
             bool isReleaseJsonDownload = downloadStatus->jobName == DownloadManager::GetJobName(DownloadType_t::DownloadTypeReleseJson);
             // DO STUFF
             if (downloadStatus->error) {
-                uprintf("Error on download.");
-                if (isReleaseJsonDownload) {
-                    JSONDownloadFailed();
-                } else {
-                    bool diskFullError = (downloadStatus->errorContext == BG_ERROR_CONTEXT_LOCAL_FILE);
-                    diskFullError = diskFullError && (downloadStatus->errorCode == HRESULT_FROM_WIN32(ERROR_DISK_FULL));
-                    m_lastErrorCause = diskFullError ? ErrorCause_t::ErrorCauseDownloadFailedDiskFull : ErrorCause_t::ErrorCauseDownloadFailed;
-                    m_downloadManager.ClearExtraDownloadJobs();
-                    ErrorOccured(m_lastErrorCause);
-                }
+				if (isReleaseJsonDownload) {
+					uprintf("JSON download failed.");
+					JSONDownloadFailed();
+				} else if (m_lastErrorCause == ErrorCause_t::ErrorCauseCancelled) {
+					uprintf("Download cancelled by user request.");
+				} else {
+					uprintf("Error on download.");
+					bool diskFullError = (downloadStatus->errorContext == BG_ERROR_CONTEXT_LOCAL_FILE);
+					diskFullError = diskFullError && (downloadStatus->errorCode == HRESULT_FROM_WIN32(ERROR_DISK_FULL));
+					m_lastErrorCause = diskFullError ? ErrorCause_t::ErrorCauseDownloadFailedDiskFull : ErrorCause_t::ErrorCauseDownloadFailed;
+					m_downloadManager.ClearExtraDownloadJobs();
+					ErrorOccured(m_lastErrorCause);
+				}
             } else if (downloadStatus->done) {
                 uprintf("Download done for %ls", downloadStatus->jobName);
 

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -293,7 +293,7 @@ private:
     void GoToSelectFilePage();
     void InitLogging();
     void EnableHibernate(bool enable = true);
-    void CancelRunningOperation();
+    void CancelRunningOperation(bool userCancel = false);
     void StartCheckInternetConnectionThread();
     bool CanUseLocalFile();
     bool CanUseRemoteFile();


### PR DESCRIPTION
The user "Cancel" button stops any ongoing downloads and then sends a
"finished all operations" message to stop the other threads. However, if
there is an ongoing download, the cancellation is reported as a download
error, and the code path for download status changes overwrites the
m_lastErrorCause = Cancelled value, and goes to the error page with
"download failed" instead. Handling the operation finished message
then also goes to the error page and re-sends the download failed etc
analytics a 2nd time. So: in the cancellation case, do nothing when
the downloads stop with an "error" and instead leave the operation
finished case to handle and propogate the cancellation "error" in
one place.

Also fix handling certain errors (eg internet disconnected) as a user-initiated
cancel (removing the files) and instead leave them as a recoverable download
error where we can resume the BITS job.

https://phabricator.endlessm.com/T13892
