### PR TITLE
Juggle hidden flags on the contents of \endless\

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -4776,7 +4776,7 @@ bool CEndlessUsbToolDlg::CopyFilesToexFAT(CEndlessUsbToolDlg *dlg, const CString
 	IFFALSE_GOTOERROR(0 != CopyFile(dlg->m_bootArchive, usbFilesPath + CSTRING_GET_LAST(dlg->m_bootArchive, '\\'), FALSE), "Error copying boot.zip file to drive.");
 	IFFALSE_GOTOERROR(0 != CopyFile(dlg->m_bootArchiveSig, usbFilesPath + CSTRING_GET_LAST(dlg->m_bootArchiveSig, '\\'), FALSE), "Error copying boot.zip signature file to drive.");
 
-	DWORD attributes = FILE_ATTRIBUTE_READONLY | FILE_ATTRIBUTE_SYSTEM | FILE_ATTRIBUTE_HIDDEN;
+	DWORD attributes = FILE_ATTRIBUTE_READONLY;
 	IFFALSE_PRINTERROR(SetAttributesForFilesInFolder(usbFilesPath, attributes), "Error on SetFileAttributes");
 
 	IFFALSE_GOTOERROR(0 != CopyFile(exePath, driveLetter + CSTRING_GET_LAST(exePath, '\\'), FALSE), "Error copying installer binary to drive.");

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -341,7 +341,7 @@ private:
 
 	static bool Has64BitSupport();
 
-	static BOOL SetAttributesForFilesInFolder(CString path, bool addAttributes);
+	static BOOL SetAttributesForFilesInFolder(CString path, DWORD attributes);
 	static BOOL SetPrivilege(HANDLE hToken, LPCTSTR lpszPrivilege, BOOL bEnablePrivilege);
 	static BOOL ChangeAccessPermissions(CString path, bool restrictAccess);
 


### PR DESCRIPTION
Here, we un-hide the contents of \endless\grub but hide the directory itself
(making it possible to fully uninstall a dual-boot Endless OS from an Endless
OS live USB); and stop setting system & hidden on combined USBs (making it
possible for mortals to delete the files and reclaim space on the disk).

https://phabricator.endlessm.com/T13895
