### PR TITLE
Handle insufficient space for dual boot install

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -3404,6 +3404,8 @@ void CEndlessUsbToolDlg::GoToSelectStoragePage()
 
 		ChangePage(_T(ELEMENT_STORAGE_PAGE));
 
+		TrackEvent(_T("StorageInsufficient"));
+
 		return;
 	}
 

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -3367,11 +3367,6 @@ void CEndlessUsbToolDlg::GoToSelectStoragePage()
 	uprintf("Available space on drive %s is %s out of %s; we need %s", systemDrive, freeSize, totalSize, SizeToHumanReadable(neededSize, FALSE, use_fake_units));
 	maxAvailableGigs = (int) ((freeBytesAvailable.QuadPart - bytesInGig) / bytesInGig);
 
-	bool enoughBytesAvailable = (freeBytesAvailable.QuadPart - bytesInGig) > neededSize;
-
-	// Enable/disable ui elements based on space availability
-	CallJavascript(_T(JS_ENABLE_ELEMENT), CComVariant(_T(ELEMENT_STORAGE_SELECT)), CComVariant(enoughBytesAvailable));
-
 	// update messages with needed space based on selected version
 	CStringA osVersion = lmprintf(isBaseImage ? MSG_400 : MSG_316);
 	CStringA osSizeText = SizeToHumanReadable((isBaseImage ? RECOMMENDED_GIGS_BASE : RECOMMENDED_GIGS_FULL) * bytesInGig, FALSE, use_fake_units);
@@ -3388,6 +3383,12 @@ void CEndlessUsbToolDlg::GoToSelectStoragePage()
 	hr = GetSelectElement(_T(ELEMENT_STORAGE_SELECT), selectElement);
 	IFFALSE_RETURN(SUCCEEDED(hr) && selectElement != NULL, "Error returned from GetSelectElement.");
 	hr = selectElement->put_length(0);
+
+	bool enoughBytesAvailable = (freeBytesAvailable.QuadPart - bytesInGig) > neededSize;
+
+	// Enable/disable ui elements based on space availability
+	CallJavascript(_T(JS_ENABLE_ELEMENT), CComVariant(_T(ELEMENT_STORAGE_SELECT)), CComVariant(enoughBytesAvailable));
+    CallJavascript(_T(JS_ENABLE_BUTTON), CComVariant(HTML_BUTTON_ID(_T(ELEMENT_SELSTORAGE_NEXT_BUTTON))), CComVariant(enoughBytesAvailable));
 
 	if (!enoughBytesAvailable) {
 		uprintf("Not enough bytes available.");

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -174,6 +174,8 @@ DWORD usbDevicesCount;
 #define ELEMENT_STORAGE_DESCRIPTION     "StorageSpaceDescription"
 #define ELEMENT_STORAGE_AVAILABLE       "SelectStorageAvailableSpace"
 #define ELEMENT_STORAGE_MESSAGE			"SelectStorageSubtitle"
+#define ELEMENT_STORAGE_AGREEMENT_TEXT	"StorageAgreementText"
+#define ELEMENT_STORAGE_SPACE_WARNING   "StorageSpaceWarning"
 #define ELEMENT_STORAGE_SUPPORT_LINK	"StorageSupportLink"
 
 //Installing page elements
@@ -3390,9 +3392,18 @@ void CEndlessUsbToolDlg::GoToSelectStoragePage()
 	CallJavascript(_T(JS_ENABLE_ELEMENT), CComVariant(_T(ELEMENT_STORAGE_SELECT)), CComVariant(enoughBytesAvailable));
     CallJavascript(_T(JS_ENABLE_BUTTON), CComVariant(HTML_BUTTON_ID(_T(ELEMENT_SELSTORAGE_NEXT_BUTTON))), CComVariant(enoughBytesAvailable));
 
+	// Show/hide space warning vs "back up your files!" notice
+	CallJavascript(_T(JS_SHOW_ELEMENT), CComVariant(_T(ELEMENT_STORAGE_AGREEMENT_TEXT)), CComVariant(enoughBytesAvailable));
+	CallJavascript(_T(JS_SHOW_ELEMENT), CComVariant(_T(ELEMENT_STORAGE_SPACE_WARNING)), CComVariant(!enoughBytesAvailable));
+
 	if (!enoughBytesAvailable) {
 		uprintf("Not enough bytes available.");
+
+		message = UTF8ToCString(lmprintf(MSG_335, SizeToHumanReadable(neededSize, FALSE, use_fake_units), freeSize, systemDriveA));
+		SetElementText(_T(ELEMENT_STORAGE_SPACE_WARNING), CComBSTR(message));
+
 		ChangePage(_T(ELEMENT_STORAGE_PAGE));
+
 		return;
 	}
 

--- a/src/endless/res/EndlessUsbTool.css
+++ b/src/endless/res/EndlessUsbTool.css
@@ -648,11 +648,15 @@ select:disabled {
 
 /* Select Storage Page */
 
-#StorageAgreementText {
+#StorageFooter {
     padding-top: 10px;
     font-size: 13px;
 	font-family: Lato;
     margin-top: 100px !important;
+}
+
+#StorageSpaceWarning {
+    color: red;
 }
 
 #SelectStoragePage .ContentTitle {

--- a/src/endless/res/EndlessUsbTool.htm
+++ b/src/endless/res/EndlessUsbTool.htm
@@ -226,8 +226,13 @@
                         <option value="2">64 GB</option>
                     </select>
                 </div>
-                <div class="ContentContainer AgreementContainer" id="StorageAgreementText">
-                    Note: We recommend backing up any important files before continuing. Should you experience any problems with your computer after installation, you can find help at <a id="StorageSupportLink">Endless Support</a>.
+                <div class="ContentContainer AgreementContainer" id="StorageFooter">
+					<div id="StorageSpaceWarning" class="hidden">
+						The selected version of Endless OS requires X GB of free disk space, but only Y GB is available. Please free up some space on drive Z:\ to continue.
+					</div>
+                    <div id="StorageAgreementText">
+						Note: We recommend backing up any important files before continuing. Should you experience any problems with your computer after installation, you can find help at <a id="StorageSupportLink">Endless Support</a>.
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
This makes the "Next" button insensitive, shows the error message we have created & translated for this case, and sends a "StorageInsufficient" event to Google Analytics.

https://phabricator.endlessm.com/T13894
