### PR TITLE
Pass non-NULL as DeviceIoControl lpBytesReturned

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -4419,7 +4419,7 @@ DWORD WINAPI CEndlessUsbToolDlg::CreateUSBStick(LPVOID param)
 	IFFALSE_GOTOERROR(hPhysical != INVALID_HANDLE_VALUE, "Error on acquiring disk handle.");
 
 	// initialize the disk
-	result = DeviceIoControl(hPhysical, IOCTL_DISK_CREATE_DISK, &createDiskData, sizeof(createDiskData), NULL, 0, NULL, NULL);
+	result = DeviceIoControl(hPhysical, IOCTL_DISK_CREATE_DISK, &createDiskData, sizeof(createDiskData), NULL, 0, &size, NULL);
 	IFFALSE_GOTOERROR(result != 0, "Error when calling IOCTL_DISK_CREATE_DISK");
 
 	// get disk geometry information


### PR DESCRIPTION
Per <https://msdn.microsoft.com/en-us/library/windows/desktop/aa365155(v=vs.85).aspx>:

> If lpOverlapped is NULL, lpBytesReturned cannot be NULL. Even when an
> operation returns no output data and lpOutBuffer is NULL,
> DeviceIoControl makes use of lpBytesReturned. After such an operation,
> the value of lpBytesReturned is meaningless.

Here, lpOverlapped (the final parameter) is NULL, so lpBytesReturned
cannot be NULL. This doesn't cause problems on Windows 10, but on Windows
7 fails with:

> Unhandled exception at 0x74FE98A6 (KERNELBASE.dll) in
> EndlessUsbTool.exe_161107_071202.dmp: 0xC0000005: Access violation writing
> location 0x00000000.

https://phabricator.endlessm.com/T13969