### PR TITLE
UEFIBootSetup: find lowest-numbered unused boot entry

### DIFF
--- a/src/endless/UEFIBootSetup.cpp
+++ b/src/endless/UEFIBootSetup.cpp
@@ -340,7 +340,7 @@ bool EFICreateNewEntry(const wchar_t *drive, wchar_t *path, wchar_t *desc) {
 	FUNCTION_ENTER;
 
 	int i;
-	int target = -1, windows = -1;
+	int target = -1;
 
 	wchar_t varname[9];
 	wchar_t volumename[1000];

--- a/src/endless/UEFIBootSetup.cpp
+++ b/src/endless/UEFIBootSetup.cpp
@@ -290,6 +290,8 @@ static BYTE vardata[10000];
 static BYTE vardata1[1000];
 
 int EFIGetBootEntryNumber(const wchar_t *desc, bool createNewEntry) {
+	FUNCTION_ENTER;
+
 	DWORD size;
 	WORD *bootorder;
 	int i;
@@ -335,6 +337,8 @@ int EFIGetBootEntryNumber(const wchar_t *desc, bool createNewEntry) {
 }
 
 bool EFICreateNewEntry(const wchar_t *drive, wchar_t *path, wchar_t *desc) {
+	FUNCTION_ENTER;
+
 	int i;
 	int target = -1, windows = -1;
 
@@ -363,7 +367,8 @@ bool EFICreateNewEntry(const wchar_t *drive, wchar_t *path, wchar_t *desc) {
 
 	bool retResult = false;
 
-	//print_entries();
+	uprintf("=== Current boot configuration ===");
+	print_entries();
 
 	target = EFIGetBootEntryNumber(desc, true);
 	IFFALSE_GOTOERROR(target != -1, "Failed to find a free boot variable");
@@ -477,7 +482,8 @@ bool EFICreateNewEntry(const wchar_t *drive, wchar_t *path, wchar_t *desc) {
 	bootorder[0] = target;
 	IFFALSE_GOTOERROR(SetFirmwareEnvironmentVariable(UEFI_VAR_BOOTORDER, UEFI_BOOT_NAMESPACE, vardata, size + extraBytes), "Error on SetFirmwareEnvironmentVariable");
 
-	//print_entries();
+	uprintf("=== New boot configuration ===");
+	print_entries();
 
 	retResult = true;
 
@@ -486,11 +492,14 @@ error:
 }
 
 bool EFIRemoveEntry(wchar_t *desc) {
+	FUNCTION_ENTER;
+
 	wchar_t varname[9];
 	int target = -1;
 	bool result = true;
 
-	//print_entries();
+	uprintf("=== Current boot configuration ===");
+	print_entries();
 
 	target = EFIGetBootEntryNumber(desc, false);
 	IFFALSE_RETURN_VALUE(target != -1, "Failed to find EFI entry for Endless OS", false);
@@ -529,7 +538,8 @@ bool EFIRemoveEntry(wchar_t *desc) {
 		uprintf("Our EFI entry %ls was not found in BootOrder list", varname);
 	}
 
-	//print_entries();
+	uprintf("=== New boot configuration ===");
+	print_entries();
 
 	return result;
 }


### PR DESCRIPTION
I observed in a log that our boot entry was numbered 8196 (== 0x2004). This
is because we find the first unused entry after the highest-numbered entry
in the boot order.

On my Lenovo Yoga 900, and presumably other Lenovo machines, the 0x200x
range is used for removable & network boot options:

    % efibootmgr
    BootCurrent: 0001
    Timeout: 0 seconds
    BootOrder: 0001,2001,2002,2003
    Boot0001* Fedora
    Boot2001* EFI USB Device
    Boot2002* EFI DVD/CDROM
    Boot2003* EFI Network

We have reports of the boot order not being updated correctly by this app
on some Lenovo machines -- perhaps they treat the 0x200x range specially.
Other distros can peacefully coexist with Windows; they probably use
efibootmgr with its default options, which finds the lowest-numbered unused
entry, full stop.

So, here is some simplified logic:

* Scan 'BootOrder'; if we find an 'Endless OS' entry, return that.
* Scan 'BootXXXX' in ascending order from 'Boot0000'; return the first
  unused one.

This implementation is slightly less neat than efibootmgr because it reads
each in-use BootXXXX variable twice: once while scanning BootOrder, and
once while finding the first variable. I think the simplicity has something
going for it, though.

https://phabricator.endlessm.com/T13963