### PR TITLE
Compare version numbers such that 3.0.9 < 3.0.10

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+# most Rufus code uses tabs
+[*]
+indent_style = tab
+
+# Endless code is an unholy mixture. Err on the side of spaces, but set
+# unambiguously-tabby files to keep with tabs for now.
+[src/endless/*]
+indent_style = space
+
+[src/endless/Analytics.*]
+indent_style = tab
+
+[src/endless/EndlessUsbTool.*]
+indent_style = tab
+
+[src/endless/StringHelperMethods.*]
+indent_style = tab
+
+[src/endless/UEFIBootSetup.*]
+indent_style = tab

--- a/src/endless/EndlessUsbTool.vcxproj
+++ b/src/endless/EndlessUsbTool.vcxproj
@@ -242,6 +242,7 @@
     <ClInclude Include="gpt\gpt_errors.h" />
     <ClInclude Include="grub\grub.h" />
     <ClInclude Include="grub\reed_solomon.h" />
+    <ClInclude Include="Images.h" />
     <ClInclude Include="json\json-forwards.h" />
     <ClInclude Include="json\json.h" />
     <ClInclude Include="localization_data.h" />
@@ -458,6 +459,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="Images.cpp" />
     <ClCompile Include="StringHelperMethods.cpp" />
     <ClCompile Include="jsoncpp.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>

--- a/src/endless/EndlessUsbTool.vcxproj.filters
+++ b/src/endless/EndlessUsbTool.vcxproj.filters
@@ -132,6 +132,9 @@
     <ClInclude Include="StringHelperMethods.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Images.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="EndlessUsbTool.cpp">
@@ -219,6 +222,9 @@
       <Filter>Source Files\grub</Filter>
     </ClCompile>
     <ClCompile Include="StringHelperMethods.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Images.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -21,6 +21,7 @@
 #include "Version.h"
 #include "WindowsUsbDefines.h"
 #include "StringHelperMethods.h"
+#include "Images.h"
 
 // Rufus include files
 extern "C" {
@@ -2533,6 +2534,7 @@ bool CEndlessUsbToolDlg::ParseJsonFile(LPCTSTR filename, bool isInstallerJson)
     Json::Reader reader;
     Json::Value rootValue, imagesElem, jsonElem, personalities, persImages, persImage, fullImage, latestEntry, bootImage;
     CString latestVersion("");
+    ImageVersion latestParsedVersion;
 
     std::ifstream jsonStream;
 
@@ -2563,8 +2565,15 @@ bool CEndlessUsbToolDlg::ParseJsonFile(LPCTSTR filename, bool isInstallerJson)
         persImages = (*it)[JSON_IMG_PERS_IMAGES];
         IFFALSE_CONTINUE(!persImages.isNull(), "Error: No personality_images entry found.");
 
-        CString currentVersion((*it)[JSON_IMG_VERSION].asCString());
-        if (currentVersion > latestVersion) {
+        const char *versionString = (*it)[JSON_IMG_VERSION].asCString();
+        CString currentVersion(versionString);
+        ImageVersion currentParsedVersion;
+        if (!ImageVersion::Parse(versionString, currentParsedVersion)) {
+            uprintf("Can't parse version '%ls'", currentVersion);
+            continue;
+        }
+        if (currentParsedVersion > latestParsedVersion) {
+            latestParsedVersion = currentParsedVersion;
             latestVersion = currentVersion;
             latestEntry = *it;
         }

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -5354,9 +5354,6 @@ bool CEndlessUsbToolDlg::SetupEndlessEFI(const CString &systemDriveLetter, const
 
 	HANDLE hPhysical;
 	bool retResult = false;
-	BYTE layout[4096] = { 0 };
-	PDRIVE_LAYOUT_INFORMATION_EX DriveLayout = (PDRIVE_LAYOUT_INFORMATION_EX)(void*)layout;
-	CStringA systemDriveA;
 	CString windowsEspDriveLetter;
 	const char *espMountLetter = NULL;
 

--- a/src/endless/Images.cpp
+++ b/src/endless/Images.cpp
@@ -1,0 +1,34 @@
+#include "stdafx.h"
+#include "Images.h"
+
+#include <iostream>
+
+bool ImageVersion::Parse(const char *str, ImageVersion &ret)
+{
+    char *s = (char *)str;
+    char *end = NULL;
+
+    ImageVersion version;
+    while (true) {
+        long int i = strtol(s, &end, 10);
+        if (s == end) {
+            return false;
+        }
+
+        if (i < 0 || i > UINT32_MAX) {
+            return false;
+        }
+
+        version.push_back((uint32_t)i);
+        if (*end == '\0') {
+            break;
+        } else if (*end == '.') {
+            s = end + 1;
+        } else {
+            return false;
+        }
+    }
+
+    ret = version;
+    return true;
+}

--- a/src/endless/Images.h
+++ b/src/endless/Images.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <vector>
+#include <cstdint>
+
+// vectors have lexicographic ordering! Hooray
+class ImageVersion : public std::vector<uint32_t> {
+public:
+    static bool Parse(const char *str, ImageVersion &ret);
+};


### PR DESCRIPTION
Tested by temporarily patching the app to fetch a different URL, which I
hand-patched to add a 3.0.10 entry.

https://phabricator.endlessm.com/T14510