### PR TITLE
Allow BITS to retry downloads

### DIFF
--- a/src/endless/DownloadManager.cpp
+++ b/src/endless/DownloadManager.cpp
@@ -448,7 +448,6 @@ bool DownloadManager::GetDownloadProgress(CComPtr<IBackgroundCopyJob> &currentJo
         break;
     case BG_JOB_STATE_ERROR:
     case BG_JOB_STATE_CANCELLED:
-    case BG_JOB_STATE_TRANSIENT_ERROR:
         downloadStatus->error = true;
         downloadStatus->errorContext = BG_ERROR_CONTEXT_NONE;
         break;

--- a/src/endless/DownloadManager.cpp
+++ b/src/endless/DownloadManager.cpp
@@ -295,7 +295,6 @@ STDMETHODIMP DownloadManager::JobModification(IBackgroundCopyJob *JobModificatio
     case BG_JOB_STATE_TRANSFERRED:
     case BG_JOB_STATE_TRANSFERRING:
     case BG_JOB_STATE_ERROR:
-    case BG_JOB_STATE_TRANSIENT_ERROR:
     case BG_JOB_STATE_CANCELLED:
         downloadStatus = new DownloadStatus_t;
         *downloadStatus = DownloadStatusNull;
@@ -316,7 +315,7 @@ STDMETHODIMP DownloadManager::JobModification(IBackgroundCopyJob *JobModificatio
         if (FAILED(hr)) JobModification->Cancel();
         downloadStatus->done = true;
     }
-    else if (BG_JOB_STATE_ERROR == State || BG_JOB_STATE_TRANSIENT_ERROR == State) {
+    else if (BG_JOB_STATE_ERROR == State) {
         //Call pJob->GetError(&pError); to retrieve an IBackgroundCopyError interface 
         //pointer which you use to determine the cause of the error.
         CComPtr<IBackgroundCopyError> error;
@@ -342,6 +341,9 @@ STDMETHODIMP DownloadManager::JobModification(IBackgroundCopyJob *JobModificatio
     else if (BG_JOB_STATE_SUSPENDED == State) {
         uprintf("Job %ls SUSPENDED\n", pszJobName);
         //m_bcJob->Cancel();
+    }
+    else if (BG_JOB_STATE_TRANSIENT_ERROR == State) {
+        uprintf("Job %ls TRANSIENT_ERROR\n", pszJobName);
     }
     else if (BG_JOB_STATE_ACKNOWLEDGED == State) {
         uprintf("Job %ls ACKNOWLEDGED\n", pszJobName);

--- a/src/endless/DownloadManager.cpp
+++ b/src/endless/DownloadManager.cpp
@@ -11,9 +11,6 @@ extern "C" {
 #define MINIMUM_RETRY_DELAY_SEC_JSON    5
 #define MINIMUM_RETRY_DELAY_SEC         20
 
-#define NO_PROGRESS_TIMEOUT_SEC_JSON    30
-#define NO_PROGRESS_TIMEOUT_SEC         600
-
 volatile ULONG DownloadManager::m_refCount = 0;
 
 DownloadManager::DownloadManager()
@@ -143,16 +140,12 @@ usecurrentjob:
         IFFALSE_GOTOERROR(SUCCEEDED(hr), "Error creating instance of IBackgroundCopyJob.");
 
         ULONG secondsRetry = MINIMUM_RETRY_DELAY_SEC;
-        ULONG secondsTimeout = MINIMUM_RETRY_DELAY_SEC;
         if (type == DownloadType_t::DownloadTypeReleseJson) {
             secondsRetry = MINIMUM_RETRY_DELAY_SEC_JSON;
-            secondsTimeout = MINIMUM_RETRY_DELAY_SEC_JSON;
         }
         currentJob->SetPriority(BG_JOB_PRIORITY_FOREGROUND);
         hr = currentJob->SetMinimumRetryDelay(secondsRetry);
         IFFALSE_PRINTERROR(SUCCEEDED(hr), "Error on SetMinimumRetryDelay");
-        hr = currentJob->SetNoProgressTimeout(secondsTimeout);
-        IFFALSE_PRINTERROR(SUCCEEDED(hr), "Error on SetNoProgressTimeout");
 
         for (auto url = urls.begin(), file = files.begin(); url != urls.end(); url++, file++) {
             uprintf("Adding download [%ls]->[%ls]", *url, *file);

--- a/src/endless/DownloadManager.h
+++ b/src/endless/DownloadManager.h
@@ -37,6 +37,7 @@ static LPCTSTR DownloadTypeToString(DownloadType_t type)
 typedef struct DownloadStatus {
     BG_JOB_PROGRESS progress;    
     bool done;
+    bool transientError;
     bool error;
     CString jobName;
     BG_ERROR_CONTEXT errorContext;
@@ -45,7 +46,7 @@ typedef struct DownloadStatus {
 
 typedef std::vector<CString> ListOfStrings;
 
-static const DownloadStatus_t DownloadStatusNull = { {0, 0, 0, 0}, false, false, L"" };
+static const DownloadStatus_t DownloadStatusNull = { {0, 0, 0, 0}, false, false, false, L"" };
 
 class DownloadManager : public IBackgroundCopyCallback {
 public:
@@ -60,7 +61,7 @@ public:
 
     static CString GetJobName(DownloadType_t type);
 
-    static bool GetDownloadProgress(CComPtr<IBackgroundCopyJob> &currentJob, DownloadStatus_t *downloadStatus, const CString &jobName);
+    static bool GetDownloadProgress(CComPtr<IBackgroundCopyJob> &currentJob, DownloadStatus_t &downloadStatus, const CString &jobName);
     static HRESULT GetExistingJob(CComPtr<IBackgroundCopyManager> &bcManager, LPCWSTR jobName, CComPtr<IBackgroundCopyJob> &existingJob);
 
     void ClearExtraDownloadJobs(bool forceCancel = false);

--- a/src/endless/DownloadManager.h
+++ b/src/endless/DownloadManager.h
@@ -79,6 +79,8 @@ public:
     }
 
 private:
+    void ReportStatus(const DownloadStatus_t &downloadStatus);
+
     LONG m_PendingJobModificationCount;
     static volatile ULONG m_refCount;
     HWND m_dispatchWindow;

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -4385,6 +4385,10 @@ void CEndlessUsbToolDlg::SetJSONDownloadState(JSONDownloadState state)
     if (state == JSONDownloadState::Failed) {
         TrackEvent(_T("Failed"), _T("ErrorCauseJSONDownloadFailed"));
     }
+    if (state == JSONDownloadState::Succeeded) {
+        // TODO: dissociate this event from the install method
+        TrackEvent(_T("JSONDownloadSucceeded"));
+    }
     UpdateDownloadableState();
 }
 

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -2470,7 +2470,12 @@ void CEndlessUsbToolDlg::StartJSONDownload()
     ListOfStrings urls = { JSON_URL(JSON_LIVE_FILE), JSON_URL(JSON_INSTALLER_FILE) };
     ListOfStrings files = { liveJson, installerJson };
 
-    success = m_downloadManager.AddDownload(DownloadType_t::DownloadTypeReleseJson, urls, files, false);
+    success = m_downloadManager.AddDownload(DownloadType_t::DownloadTypeReleseJson, urls, files, true);
+    if (!success) {
+        // If resuming a possibly-existing download failed, try harder to start a new one.
+        // In theory this shouldn't be necessary but this is done for the image download case so who knows!
+        success = m_downloadManager.AddDownload(DownloadType_t::DownloadTypeReleseJson, urls, files, false);
+    }
 
     if(!success) {
         JSONDownloadFailed();

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -1434,9 +1434,6 @@ LRESULT CEndlessUsbToolDlg::WindowProc(UINT message, WPARAM wParam, LPARAM lPara
 
             if (m_isConnected) {
                 StartJSONDownload();
-            } else if(m_currentStep == OP_DOWNLOADING_FILES) {
-                m_lastErrorCause = ErrorCause_t::ErrorCauseDownloadFailed;
-                CancelRunningOperation();
             }
 
             UpdateDownloadableState();

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -1332,7 +1332,7 @@ LRESULT CEndlessUsbToolDlg::WindowProc(UINT message, WPARAM wParam, LPARAM lPara
                     }
 
                     CStringA strDownloaded = SizeToHumanReadable(downloadStatus->progress.BytesTransferred, FALSE, use_fake_units);
-                    CStringA strTotal = SizeToHumanReadable(totalSize, FALSE, use_fake_units);
+                    CStringA strTotal = totalSize == BG_SIZE_UNKNOWN ? "---" : SizeToHumanReadable(totalSize, FALSE, use_fake_units);
                     // push to UI
                     CString downloadString = UTF8ToCString(lmprintf(MSG_302, strDownloaded, strTotal, speed));
                     SetElementText(_T(ELEMENT_INSTALL_STATUS), CComBSTR(downloadString));

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -4153,22 +4153,13 @@ DWORD WINAPI CEndlessUsbToolDlg::CheckInternetConnectionThread(void* param)
             {
                 flags = 0;
                 result = InternetGetConnectedState(&flags, 0);
-                IFFALSE_BREAK(result, "Device not connected to internet.");
 
-				// require a working server check to discovery connectivity
-				// in the first place, but once we've got a connection, only
-				// the device/adapter going away will take us offline again
-				if (!connected) {
-					result = InternetCheckConnection(JSON_URL(JSON_LIVE_FILE), FLAG_ICC_FORCE_CONNECTION, 0);
-					IFFALSE_BREAK(result, "Cannot connect to server hosting the JSON file.");
-				}
-
-                result = TRUE;
                 break;
             }
         }
 
         if (firstTime || result != connected) {
+            uprintf("InternetGetConnectedState changed: %s (flags %d)", result ? "online" : "offline", flags);
             firstTime = FALSE;
             connected = result;
             ::PostMessage(dlg->m_hWnd, WM_INTERNET_CONNECTION_STATE, (WPARAM)connected, 0);

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -372,7 +372,6 @@ static LPCTSTR ErrorCauseToStr(ErrorCause_t errorCause)
     {
         TOSTR(ErrorCauseGeneric);
         TOSTR(ErrorCauseCancelled);
-        TOSTR(ErrorCauseJSONDownloadFailed);
         TOSTR(ErrorCauseDownloadFailed);
         TOSTR(ErrorCauseDownloadFailedDiskFull);
         TOSTR(ErrorCauseVerificationFailed);
@@ -1675,7 +1674,6 @@ void CEndlessUsbToolDlg::ErrorOccured(ErrorCause_t errorCause)
         headlineMsgId = MSG_350;
         suggestionMsgId = MSG_351;
         break;
-    case ErrorCause_t::ErrorCauseJSONDownloadFailed:
     case ErrorCause_t::ErrorCauseVerificationFailed:
         buttonMsgId = MSG_327;
         suggestionMsgId = MSG_324;
@@ -3535,7 +3533,6 @@ HRESULT CEndlessUsbToolDlg::OnRecoverErrorButtonClicked(IHTMLElement* pElement)
         break;
     }
     case ErrorCause_t::ErrorCauseCancelled:
-    case ErrorCause_t::ErrorCauseJSONDownloadFailed:
     default:
         ChangePage(_T(ELEMENT_DUALBOOT_PAGE));
         break;
@@ -4378,6 +4375,9 @@ void CEndlessUsbToolDlg::SetJSONDownloadState(JSONDownloadState state)
     FUNCTION_ENTER_FMT("%d", state);
 
     m_jsonDownloadState = state;
+    if (state == JSONDownloadState::Failed) {
+        TrackEvent(_T("Failed"), _T("ErrorCauseJSONDownloadFailed"));
+    }
     UpdateDownloadableState();
 }
 

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -4129,7 +4129,7 @@ DWORD WINAPI CEndlessUsbToolDlg::UpdateDownloadProgressThread(void* param)
     }
 
 done:
-
+    dlg->m_downloadUpdateThread = INVALID_HANDLE_VALUE;
     CoUninitialize();
     return 0;
 }

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -268,6 +268,7 @@ private:
     bool UnpackFile(const CString &archive, const CString &destination, int compressionType = 0, void* progress_function = NULL, unsigned long* cancel_request = NULL);
     bool ParseJsonFile(LPCTSTR filename, bool isInstallerJson);
     void AddDownloadOptionsToUI();
+    void UpdateDownloadableState();
 
     void ErrorOccured(ErrorCause_t errorCause);
 

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -28,7 +28,6 @@ typedef struct FileImageEntry {
 typedef enum ErrorCause {
     ErrorCauseGeneric,
     ErrorCauseCancelled,
-    ErrorCauseJSONDownloadFailed,
     ErrorCauseDownloadFailed,
     ErrorCauseDownloadFailedDiskFull,
     ErrorCauseVerificationFailed,

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -68,6 +68,7 @@ typedef enum InstallMethod {
 
 enum JSONDownloadState {
     Pending,
+    Retrying,
     Failed,
     Succeeded
 };

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -67,6 +67,12 @@ typedef enum InstallMethod {
 	UninstallDualBoot
 } InstallMethod_t;
 
+enum JSONDownloadState {
+    Pending,
+    Failed,
+    Succeeded
+};
+
 // CEndlessUsbToolDlg dialog
 class CEndlessUsbToolDlg : public CDHtmlDialog
 {
@@ -186,7 +192,7 @@ private:
     int m_currentStep;
     bool m_isConnected;
     bool m_localFilesScanned;
-    bool m_jsonDownloadAttempted;
+    JSONDownloadState m_jsonDownloadState;
     CMap<CString, LPCTSTR, pFileImageEntry_t, pFileImageEntry_t> m_imageFiles;
     CList<CString> m_imageIndexToPath;
     CList<RemoteImageEntry_t> m_remoteImages;
@@ -313,7 +319,7 @@ private:
     void FindMaxUSBSpeed();
     void CheckUSBHub(LPCTSTR devicePath);
     void UpdateUSBSpeedMessage(int deviceIndex);
-    void JSONDownloadFailed();
+    void SetJSONDownloadState(JSONDownloadState state);
 
 	void GoToSelectStoragePage();
 	BOOL AddStorageEntryToSelect(CComPtr<IHTMLSelectElement> &selectElement, int noOfGigs, uint8_t extraData);

--- a/src/endless/GeneralCode.h
+++ b/src/endless/GeneralCode.h
@@ -22,6 +22,8 @@
 #define safe_closefile(__file__) if (__file__ != NULL) { fclose(__file__); __file__ = NULL; }
 
 #define FUNCTION_ENTER uprintf("%s:%d %s", __FILE__, __LINE__, __FUNCTION__)
+#define FUNCTION_ENTER_FMT(fmt, ...) uprintf("%s:%d %s " fmt, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+
 
 /* Command copied from https://gitlab.com/tortoisegit/tortoisegit/blob/e1262ead5495ecc7902b61ac3e1f3da22294bb2d/src/version.h */
 /* gpg --armor --export 587A279C | sed -e s/^/\"/ -e s/\$/\\\\n\"/ */


### PR DESCRIPTION
The changes are, roughly:

* Don't terminate downloads when the connection state changes
* Treat TRANSIENT_ERROR for image downloads as "the download is proceeding", not as if it were ERROR
* Show an error on TRANSIENT_ERROR for the JSON download, but keep retrying
* Don't set absurdly low timeouts on BITS jobs
* Ensure we always notify the UI when a real error occurs (a bug masked by all the above)
* drop the JSONDownloadFailed error state entirely, since it is no longer a "jump-to-the-error-page" kind of error, and add a separate analytics event for that case to track its frequency

https://phabricator.endlessm.com/T14535