### PR TITLE
CanUseRemoteFile: handle ::Retrying state

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -4247,7 +4247,7 @@ bool CEndlessUsbToolDlg::CanUseLocalFile()
 // Returns true if we might, in principle, be able to use a remote file.
 bool CEndlessUsbToolDlg::CanUseRemoteFile()
 {
-    return m_jsonDownloadState == JSONDownloadState::Pending || m_remoteImages.GetCount() != 0;
+    return m_jsonDownloadState != JSONDownloadState::Failed || m_remoteImages.GetCount() != 0;
 }
 
 void CEndlessUsbToolDlg::FindMaxUSBSpeed()


### PR DESCRIPTION
This is only called in ::GoToSelectFilePage():

    // ...
    } else if(CanUseRemoteFile()) {
        ApplyRufusLocalization();
    } else {
        uprintf("No remote images available and no local images available.");
    }
    // ...

I don't understand why we would need to update localized strings here,
so I think the only ill effect would be a spurious debug string...

https://phabricator.endlessm.com/T14535