### PR TITLE
Use the latest released version; use .json.gz; some trivia

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -2624,14 +2624,12 @@ bool CEndlessUsbToolDlg::ParseJsonFile(LPCTSTR filename, bool isInstallerJson)
             if(remoteImage.extractedSize == 0) remoteImage.extractedSize = remoteImage.compressedSize;            
             remoteImage.urlFile = fullImage[JSON_IMG_URL_FILE].asCString();
             remoteImage.urlSignature = fullImage[JSON_IMG_URL_SIG].asCString();
-            remoteImage.urlBootArchive = CSTRING_GET_PATH(CSTRING_GET_PATH(remoteImage.urlFile, L'.'), L'.') + BOOT_ARCHIVE_SUFFIX;
-            remoteImage.urlBootArchiveSignature = remoteImage.urlBootArchive + SIGNATURE_FILE_EXT;
             remoteImage.personality = persIt->asCString();
             remoteImage.version = latestVersion;
             remoteImage.urlUnpackedSignature = fullImage[JSON_IMG_UNPACKED_URL_SIG].asCString();
 
             if(!isInstallerJson) {
-                bootImage = persImage["boot"];
+                bootImage = persImage[JSON_IMG_BOOT];
                 IFFALSE_CONTINUE(!bootImage.isNull(), CString("'boot' entry not found for personality - ") + persIt->asCString());
                 CHECK_ENTRY(bootImage, JSON_IMG_COMPRESSED_SIZE);
                 CHECK_ENTRY(bootImage, JSON_IMG_URL_FILE);

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -4025,6 +4025,8 @@ void CEndlessUsbToolDlg::GetImgDisplayName(CString &displayName, const CString &
 {
     FUNCTION_ENTER;
 
+    // TODO: the JSON file is only parsed once, so m_selectedInstallMethod might well be a different value to what the user ultimately selects.
+    // We should format the image size at the last possible moment.
     ULONGLONG actualsize = m_selectedInstallMethod == InstallMethod_t::ReformatterUsb ? (size + m_installerImage.compressedSize) : size;
     // Create display name
     displayName = _T(ENDLESS_OS);

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -290,7 +290,7 @@ enum endless_action_type {
 
 #define TID_UPDATE_FILES                TID_REFRESH_TIMER + 1
 
-//#define ENABLE_JSON_COMPRESSION 1
+#define ENABLE_JSON_COMPRESSION 1
 
 #define BOOT_COMPONENTS_FOLDER	"EndlessBoot"
 


### PR DESCRIPTION
The key detail I missed in my previous attempt to fix this bug is that 'persImages' is only assigned to in the first ("pick a version") loop. This means that even the old logic, which compared the versions as strings, would actually just pick whichever set of URLs happened to be last in the JSON file. JsonCpp happens to preserve ordering within objects, and we happen to sort the keys when generating the JSON, so in practice this was equivalent for as long as string comparisons on versions was enough...

https://phabricator.endlessm.com/T14510