### PR TITLE
AppVeyor: verify that rufus.pot has been updated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,5 @@ install-sh      eol=lf
 .gitattributes  export-ignore
 .gitignore      export-ignore
 *.creole        export-ignore
+*.po            eol=lf
+*.pot           eol=lf

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,3 +36,8 @@ after_build:
   - appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\endless-installer-%EI_VERSION%.exe
   - 7z a endless-installer-%EI_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\endless-installer-%EI_VERSION%.exe
   - appveyor PushArtifact endless-installer-%EI_VERSION%.zip
+
+test_script:
+  - echo "Checking rufus.pot is up-to-date"
+  - C:\Python35-x64\python.exe %APPVEYOR_BUILD_FOLDER%\po\loc2pot
+  - git diff --exit-code -- %APPVEYOR_BUILD_FOLDER%\po\rufus.pot

--- a/po/loc2pot
+++ b/po/loc2pot
@@ -7,7 +7,8 @@ import re
 # that can be used with standard translation tools such as Transifex
 
 PO_DIR = os.path.dirname(__file__)
-LOC_FILE = os.path.join(PO_DIR, '../src/endless/res/endless.loc')
+LOC_FILE = os.path.normpath(os.path.join(
+    PO_DIR, '..', 'src', 'endless', 'res', 'endless.loc'))
 POT_FILE = os.path.join(PO_DIR, 'rufus.pot')
 
 PREAMBLE = '''# SOME DESCRIPTIVE TITLE.
@@ -38,7 +39,8 @@ def is_c_format_string(label):
     return m is not None and not m.group(1).startswith('02')
 
 
-with open(LOC_FILE) as loc_file, open(POT_FILE, 'w') as pot_file:
+with open(LOC_FILE, 'r', encoding='utf-8') as loc_file, \
+     open(POT_FILE, 'w', newline='\n', encoding='utf-8') as pot_file:
     pot_file.write(PREAMBLE)
     found = False
     in_debug_block = False


### PR DESCRIPTION
I added a new translatable string but forgot to run loc2pot and commit the result. The weekly job which pushes new untranslated strings to Transifex does not know how to run this script (as far as I can tell); so we should either arrange for it to do so, or check that it's been done by hand.

In a way I think it's better done by hand, in case there's some new unexpected bug in the script.