### PR TITLE
Show 'sea' personality as id, th, vi

### DIFF
--- a/po/rufus.pot
+++ b/po/rufus.pot
@@ -678,3 +678,18 @@ msgstr ""
 msgctxt "MSG_409"
 msgid "Spanish (Mexico)"
 msgstr ""
+
+#, c-format
+msgctxt "MSG_410"
+msgid "Indonesian"
+msgstr ""
+
+#, c-format
+msgctxt "MSG_411"
+msgid "Thai"
+msgstr ""
+
+#, c-format
+msgctxt "MSG_412"
+msgid "Vietnamese"
+msgstr ""

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -4037,10 +4037,11 @@ void CEndlessUsbToolDlg::GetImgDisplayName(CString &displayName, const CString &
     displayName += " ";
     displayName += version;
     displayName += " ";
-    displayName += LocalizePersonalityName(personality);
+    bool isBase = personality == PERSONALITY_BASE;
+    displayName += UTF8ToCString(lmprintf(isBase ? MSG_400 : MSG_316));
     if (personality != PERSONALITY_BASE) {
-        displayName += " ";
-        displayName += UTF8ToCString(lmprintf(MSG_316));
+        displayName += " - ";
+        displayName += LocalizePersonalityName(personality);
     }
     if (size != 0) {
         displayName += " - ";

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -219,6 +219,7 @@ private:
     FileImageEntry_t m_localInstallerImage;
     static CMap<CString, LPCTSTR, uint32_t, uint32_t> m_personalityToLocaleMsg;
     static CMap<CStringA, LPCSTR, CString, LPCTSTR> m_localeToPersonality;
+    static CMap<CStringA, LPCSTR, CString, LPCTSTR> CEndlessUsbToolDlg::m_localeToDisplayPersonality;
     static CMap<CStringA, LPCSTR, CStringA, LPCSTR> m_localeToIniLocale;
 
     CString m_localFile;
@@ -293,6 +294,8 @@ private:
     bool UnpackFile(const CString &archive, const CString &destination, int compressionType = 0, void* progress_function = NULL, unsigned long* cancel_request = NULL);
     bool UnpackImage(const CString &image, const CString &destination);
     bool ParseJsonFile(LPCTSTR filename, bool isInstallerJson);
+    void GetPreferredPersonality(CString &personality);
+    void GetPreferredDisplayPersonality(CString & personality);
     void AddDownloadOptionsToUI();
     void UpdateDownloadableState();
 

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -65,7 +65,6 @@ typedef struct RemoteImageEntry {
     CString urlBootArchive;
     CString urlBootArchiveSignature;
 	ULONGLONG bootArchiveSize;
-    CString displayName;
     CString downloadJobName;
     CString version;
 } RemoteImageEntry_t, *pRemoteImageEntry_t;

--- a/src/endless/Resource.h
+++ b/src/endless/Resource.h
@@ -221,9 +221,12 @@
 #define MSG_407                         3407
 #define MSG_408                         3408
 #define MSG_409                         3409
+#define MSG_410                         3410
+#define MSG_411                         3411
+#define MSG_412                         3412
 
 
-#define MSG_MAX                         MSG_409 + 1
+#define MSG_MAX                         MSG_412 + 1
 
 // Next default values for new objects
 // 

--- a/src/endless/res/endless.loc
+++ b/src/endless/res/endless.loc
@@ -284,6 +284,9 @@ t MSG_406 "Chinese Simplified"
 t MSG_407 "Bengali"
 t MSG_408 "Spanish (Guatemala)"
 t MSG_409 "Spanish (Mexico)"
+t MSG_410 "Indonesian"
+t MSG_411 "Thai"
+t MSG_412 "Vietnamese"
 
 ################################################################################
 ############################# TRANSLATOR END COPY ##############################

--- a/src/endless/res/endless.loc
+++ b/src/endless/res/endless.loc
@@ -1357,6 +1357,7 @@ t MSG_405 "Perancis"
 t MSG_406 "Tionghoa Sederhana"
 t MSG_407 "Bengali"
 t MSG_408 "Spanyol (Guatemala)"
+t MSG_410 "Bahasa Indonesia"
 
 ################################################################################
 l "pt-BR" "Portuguese Brazilian (Português do Brasil)" 0x0416
@@ -1813,6 +1814,7 @@ t MSG_406 "อักษรจีนตัวย่อ"
 t MSG_407 "เบงกาลี"
 t MSG_408 "สเปน (กัวเตมาลา)"
 t MSG_409 "สเปน (เม็กซิโก)"
+t MSG_411 "ไทย"
 
 ################################################################################
 l "vi-VN" "Vietnamese (Tiếng Việt)" 0x042A
@@ -1965,6 +1967,7 @@ t MSG_406 "Tiếng Trung giản thể"
 t MSG_407 "Tiếng Bengal"
 t MSG_408 "Tiếng Tây Ban Nha (Guatemala)"
 t MSG_409 "Tiếng Tây Ban Nha (Mexico)"
+t MSG_412 "Tiếng Việt"
 
 ################################################################################
 l "zh-CN" "Chinese Simplified (简体中文)" 0x0804, 0x1004


### PR DESCRIPTION
If we are running in one of those locales, we show it as that language; if
not, we show it as the three languages, comma-separated.

The other option would be to show three options, one for each language, in
the list. That's a bit more invasive to achieve, so I took this route. We
need logic like this for the local image list, in any case, unless we want
to show three entries in *that* list for one file.

With this change, the personality-based sort order appears even more wrong
even in English:

* Arabic
* Bengali
* English
* Spanish
* Spanish (Guatemala)
* Spanish (Mexico)
* French
* Portuguese (Brazilian)
* Indonesian, Thai, Vietnamese
* Chinese (Simplified)

At least it's stable!

This PR also includes a few other fixes to localized personality names.

https://phabricator.endlessm.com/T15642