### PR TITLE
Add font size for "advanced options" sentence

### DIFF
--- a/src/endless/res/EndlessUsbTool.css
+++ b/src/endless/res/EndlessUsbTool.css
@@ -382,6 +382,7 @@ select:disabled {
 
 #AdvancedOptionsText {
     margin-top: 20px;
+    font-size: 14px;
 }
 
 


### PR DESCRIPTION
On hidpi screens this is twice the size of all other text in the dialog,
and looks even more ridiculous than the dialog just being too small.

https://phabricator.endlessm.com/T14107