### PR TITLE
DownloadManager: log HRESULTs, not GetLastError()

### DIFF
--- a/src/endless/EndlessUsbTool.vcxproj
+++ b/src/endless/EndlessUsbTool.vcxproj
@@ -482,6 +482,7 @@
     <ClCompile Include="EndlessISO.cpp" />
     <ClCompile Include="EndlessUsbTool.cpp" />
     <ClCompile Include="EndlessUsbToolDlg.cpp" />
+    <ClCompile Include="GeneralCode.cpp" />
     <ClCompile Include="gpt\crc32.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>

--- a/src/endless/EndlessUsbTool.vcxproj.filters
+++ b/src/endless/EndlessUsbTool.vcxproj.filters
@@ -236,6 +236,9 @@
     <ClCompile Include="EndlessISO.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="GeneralCode.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="res\EndlessUsbTool.rc2">

--- a/src/endless/GeneralCode.cpp
+++ b/src/endless/GeneralCode.cpp
@@ -1,0 +1,10 @@
+#include "stdafx.h"
+#include "GeneralCode.h"
+
+void _print_hresult(const char *file, int line, const char *msg, HRESULT hr)
+{
+    _com_error err(hr);
+    LPCTSTR errMsg = err.ErrorMessage();
+
+    uprintf("%s:%d %s (HRESULT: 0x%x %ls)", file, line, msg, hr, errMsg);
+}

--- a/src/endless/GeneralCode.h
+++ b/src/endless/GeneralCode.h
@@ -16,6 +16,9 @@ extern "C" {
 
 #define PRINT_ERROR_MSG(__ERROR_MSG__) uprintf("%s:%d %s (GLE=[%d])",__FILE__, __LINE__, __ERROR_MSG__, GetLastError())
 
+void _print_hresult(const char *file, int line, const char *msg, HRESULT hr);
+#define PRINT_HRESULT(hr, msg) _print_hresult(__FILE__, __LINE__, msg, hr)
+
 #define IFFALSE_PRINTERROR(__CONDITION__, __ERRROR_MSG__) if(!(__CONDITION__)) { if(strlen(__ERRROR_MSG__)) PRINT_ERROR_MSG(__ERRROR_MSG__); }
 #define IFFALSE_GOTOERROR(__CONDITION__, __ERRROR_MSG__) if(!(__CONDITION__)) { if(strlen(__ERRROR_MSG__)) PRINT_ERROR_MSG(__ERRROR_MSG__); goto error; }
 #define IFFALSE_GOTO(__CONDITION__, __ERRROR_MSG__, __LABEL__) if(!(__CONDITION__)) { PRINT_ERROR_MSG(__ERRROR_MSG__); goto __LABEL__; }
@@ -27,6 +30,11 @@ extern "C" {
 #define IFTRUE_GOTO(__CONDITION__, __ERRROR_MSG__, __LABEL__) if((__CONDITION__)) { PRINT_ERROR_MSG(__ERRROR_MSG__); goto __LABEL__; }
 #define IFTRUE_GOTOERROR(__CONDITION__, __ERRROR_MSG__) if((__CONDITION__)) { PRINT_ERROR_MSG(__ERRROR_MSG__); goto error; }
 #define IFTRUE_RETURN(__CONDITION__, __ERRROR_MSG__) if((__CONDITION__)) { PRINT_ERROR_MSG(__ERRROR_MSG__); return; }
+
+#define IFFAILED_PRINTERROR(hr, msg)  { HRESULT __hr__ = (hr); if (FAILED(__hr__)) { PRINT_HRESULT(__hr__, msg); } }
+#define IFFAILED_GOTO(hr, msg, label) { HRESULT __hr__ = (hr); if (FAILED(__hr__)) { PRINT_HRESULT(__hr__, msg); goto label; } }
+#define IFFAILED_CONTINUE(hr, msg)    { HRESULT __hr__ = (hr); if (FAILED(__hr__)) { PRINT_HRESULT(__hr__, msg); continue; } }
+#define IFFAILED_GOTOERROR(hr, msg)   IFFAILED_GOTO(hr, msg, error)
 
 #define safe_closefile(__file__) if (__file__ != NULL) { fclose(__file__); __file__ = NULL; }
 


### PR DESCRIPTION
When testing running from an ISO, I saw this error:

> The requested lookup key was not found in any active activation context.

but the real cause was E_ACCESSDENIED: the download dir is on a read-only filesystem.