### PR TITLE
Don't include download size in maximum install size

### DIFF
--- a/src/endless/EndlessUsbTool.vcxproj
+++ b/src/endless/EndlessUsbTool.vcxproj
@@ -292,6 +292,7 @@
     <ClInclude Include="json\json-forwards.h" />
     <ClInclude Include="json\json.h" />
     <ClInclude Include="localization_data.h" />
+    <ClInclude Include="Log2LL.h" />
     <ClInclude Include="PGPSignature.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="stdafx.h" />

--- a/src/endless/EndlessUsbTool.vcxproj.filters
+++ b/src/endless/EndlessUsbTool.vcxproj.filters
@@ -147,6 +147,9 @@
     <ClInclude Include="Eosldr.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Log2LL.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="EndlessUsbTool.cpp">

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -1795,18 +1795,24 @@ void CEndlessUsbToolDlg::ErrorOccured(ErrorCause_t errorCause)
     if (suggestionMsgId != 0) {
         CComBSTR message;
         if (suggestionMsgId == MSG_334 || suggestionMsgId == MSG_303) {
+            // Not enough space to download
             POSITION p = m_remoteImages.FindIndex(m_selectedRemoteIndex);
             ULONGLONG size = 0;
             if (p != NULL) {
                 RemoteImageEntry_t remote = m_remoteImages.GetAt(p);
-                size = remote.compressedSize;
+                size = remote.compressedSize + remote.bootArchiveSize;
             }
             // we don't take the signature files into account but we are taking about ~2KB compared to >2GB
             ULONGLONG totalSize = size + (m_selectedInstallMethod == InstallMethod_t::ReformatterUsb ? m_installerImage.compressedSize : 0);
             message = UTF8ToBSTR(lmprintf(suggestionMsgId, SizeToHumanReadable(totalSize, FALSE, use_fake_units)));
         } else if(suggestionMsgId == MSG_351 || suggestionMsgId == MSG_301) {
-            ULONGLONG neededSize = GetNeededSpaceForDualBoot();
-            message = UTF8ToBSTR(lmprintf(suggestionMsgId, SizeToHumanReadable(neededSize, FALSE, use_fake_units), ConvertUnicodeToUTF8(GetSystemDrive())));
+            // Not enough space to install (either our size logic is buggy, or
+            // the user downloaded some other huge file between choosing a size
+            // and the download finishing?)
+            ULONGLONG downloadSize = 0;
+            ULONGLONG neededSize = GetNeededSpaceForDualBoot(&downloadSize);
+            CStringA humanSize = SizeToHumanReadable(neededSize + downloadSize + BYTES_IN_GIGABYTE, FALSE, use_fake_units);
+            message = UTF8ToBSTR(lmprintf(suggestionMsgId, humanSize, ConvertUnicodeToUTF8(GetSystemDrive())));
         } else {
             message = UTF8ToBSTR(lmprintf(suggestionMsgId));
         }
@@ -3456,8 +3462,14 @@ HRESULT CEndlessUsbToolDlg::OnSelectedStorageSizeChanged(IHTMLElement* pElement)
 #define IS_MAXIMUM_VALUE		2
 #define IS_BASE_IMAGE			3
 
-ULONGLONG CEndlessUsbToolDlg::GetNeededSpaceForDualBoot(bool *isBaseImage)
+// Returns the minimum size required to install the currently-selected image,
+// including padding to give the user free space to install updates and apps.
+// If the image needs to be downloaded, and the download destination is the
+// same as the install drive, downloadSize is set to the space required for
+// the download; otherwise, it's 0.
+ULONGLONG CEndlessUsbToolDlg::GetNeededSpaceForDualBoot(ULONGLONG *downloadSize, bool *isBaseImage)
 {
+	*downloadSize = 0;
 	if(isBaseImage != NULL)  *isBaseImage = true;
 	// figure out how much space we need
 	ULONGLONG neededSize = 0;
@@ -3477,7 +3489,7 @@ ULONGLONG CEndlessUsbToolDlg::GetNeededSpaceForDualBoot(bool *isBaseImage)
 			RemoteImageEntry_t remote = m_remoteImages.GetAt(p);
 			neededSize = remote.extractedSize;
 			if (GetExePath().Left(3) == GetSystemDrive()) {
-				neededSize += remote.compressedSize + remote.bootArchiveSize;
+				*downloadSize = remote.compressedSize + remote.bootArchiveSize;
 			}
 			if (isBaseImage != NULL)  *isBaseImage = (remote.personality == PERSONALITY_BASE);
 		}
@@ -3491,12 +3503,14 @@ void CEndlessUsbToolDlg::GoToSelectStoragePage()
 	ULARGE_INTEGER freeBytesAvailable, totalNumberOfBytes, totalNumberOfFreeBytes;
 	CComPtr<IHTMLSelectElement> selectElement;
 	HRESULT hr;
-	ULONGLONG maxAvailableSize = 0;
+	ULONGLONG maximumInstallSize = 0;
 	CStringA freeSize, totalSize;
 	bool isBaseImage = true;
 
 	ULONGLONG bytesInGig = BYTES_IN_GIGABYTE;
-	ULONGLONG neededSize = GetNeededSpaceForDualBoot(&isBaseImage);
+	ULONGLONG downloadSize = 0;
+	ULONGLONG minimumInstallSize = GetNeededSpaceForDualBoot(&downloadSize, &isBaseImage);
+	ULONGLONG totalSpaceNeeded = downloadSize + minimumInstallSize + bytesInGig;
 
 	CStringW systemDrive = GetSystemDrive();
 	CStringA systemDriveA = ConvertUnicodeToUTF8(systemDrive);
@@ -3505,8 +3519,13 @@ void CEndlessUsbToolDlg::GoToSelectStoragePage()
 	IFFALSE_RETURN(GetDiskFreeSpaceEx(systemDrive, &freeBytesAvailable, &totalNumberOfBytes, &totalNumberOfFreeBytes) != 0, "Error on GetDiskFreeSpace");
 	totalSize = SizeToHumanReadable(totalNumberOfBytes.QuadPart, FALSE, use_fake_units);
 	freeSize = SizeToHumanReadable(freeBytesAvailable.QuadPart, FALSE, use_fake_units);
-	uprintf("Available space on drive %s is %s out of %s; we need %s", systemDrive, freeSize, totalSize, SizeToHumanReadable(neededSize, FALSE, use_fake_units));
-	maxAvailableSize = (freeBytesAvailable.QuadPart - bytesInGig);
+	{
+		CStringA downloadSizeStr = SizeToHumanReadable(downloadSize, FALSE, use_fake_units);
+		CStringA minimumInstallSizeStr = SizeToHumanReadable(minimumInstallSize, FALSE, use_fake_units);
+		uprintf("Available space on drive %s is %s out of %s; we need %s to download and %s to install",
+			systemDrive, freeSize, totalSize, downloadSizeStr, minimumInstallSizeStr);
+	}
+	maximumInstallSize = (freeBytesAvailable.QuadPart - bytesInGig) - downloadSize;
 
 	// update messages with needed space based on selected version
 	CStringA osVersion = lmprintf(isBaseImage ? MSG_400 : MSG_316);
@@ -3526,7 +3545,7 @@ void CEndlessUsbToolDlg::GoToSelectStoragePage()
 	IFFALSE_RETURN(SUCCEEDED(hr) && selectElement != NULL, "Error returned from GetSelectElement.");
 	hr = selectElement->put_length(0);
 
-	bool enoughBytesAvailable = (freeBytesAvailable.QuadPart - bytesInGig) > neededSize;
+	bool enoughBytesAvailable = totalSpaceNeeded < freeBytesAvailable.QuadPart;
 
 	// Enable/disable ui elements based on space availability
 	CallJavascript(_T(JS_ENABLE_ELEMENT), CComVariant(_T(ELEMENT_STORAGE_SELECT)), CComVariant(enoughBytesAvailable));
@@ -3539,7 +3558,7 @@ void CEndlessUsbToolDlg::GoToSelectStoragePage()
 	if (!enoughBytesAvailable) {
 		uprintf("Not enough bytes available.");
 
-		message = UTF8ToCString(lmprintf(IsCoding() ? MSG_374 : MSG_335, SizeToHumanReadable(neededSize, FALSE, use_fake_units), freeSize, systemDriveA));
+		message = UTF8ToCString(lmprintf(IsCoding() ? MSG_374 : MSG_335, SizeToHumanReadable(totalSpaceNeeded, FALSE, use_fake_units), freeSize, systemDriveA));
 		SetElementText(_T(ELEMENT_STORAGE_SPACE_WARNING), CComBSTR(message));
 
 		ChangePage(_T(ELEMENT_STORAGE_PAGE));
@@ -3550,17 +3569,17 @@ void CEndlessUsbToolDlg::GoToSelectStoragePage()
 	}
 
 	// Add the entries
-	m_selectedInstallSizeBytes = neededSize;
-	IFFALSE_RETURN(AddStorageEntryToSelect(selectElement, neededSize, IS_MINIMUM_VALUE), "Error adding value to select.");
+	m_selectedInstallSizeBytes = minimumInstallSize;
+	IFFALSE_RETURN(AddStorageEntryToSelect(selectElement, minimumInstallSize, IS_MINIMUM_VALUE), "Error adding value to select.");
 
 	// next power of 2 greater than minimum size
-	uint64_t size = 1LL << (log2ll(neededSize) + 1);
+	uint64_t size = 1LL << (log2ll(minimumInstallSize) + 1);
 
-	for (; size < maxAvailableSize; size *= 2) {
+	for (; size < maximumInstallSize; size *= 2) {
 		IFFALSE_RETURN(AddStorageEntryToSelect(selectElement, size, isBaseImage ? IS_BASE_IMAGE : 0), "Error adding value to select.");
 	}
 
-	IFFALSE_RETURN(AddStorageEntryToSelect(selectElement, maxAvailableSize, IS_MAXIMUM_VALUE), "Error adding value to select.");
+	IFFALSE_RETURN(AddStorageEntryToSelect(selectElement, maximumInstallSize, IS_MAXIMUM_VALUE), "Error adding value to select.");
 
 	ChangePage(_T(ELEMENT_STORAGE_PAGE));
 }

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -211,7 +211,7 @@ protected:
 
 private:
 	BOOL m_initialized;
-	int m_nrGigsSelected;
+	uint64_t m_selectedInstallSizeBytes;
 	loc_cmd* m_selectedLocale;
 	char m_localizationFile[MAX_PATH];
 	ULONG m_shellNotificationsRegister;
@@ -393,7 +393,7 @@ private:
     void SetJSONDownloadState(JSONDownloadState state);
 
 	void GoToSelectStoragePage();
-	BOOL AddStorageEntryToSelect(CComPtr<IHTMLSelectElement> &selectElement, int noOfGigs, uint8_t extraData);
+	BOOL AddStorageEntryToSelect(CComPtr<IHTMLSelectElement> &selectElement, uint64_t bytes, uint8_t extraData);
 
 	void ChangeDriveAutoRunAndMount(bool setEndlessValues);
 
@@ -415,7 +415,7 @@ private:
 	static bool SetupDualBootFiles(CEndlessUsbToolDlg *dlg, const CString &systemDriveLetter, const CString &bootFilesPath, ErrorCause &errorCause);
 
 	static bool EnsureUncompressed(const CString &filePath);
-	static bool ExtendImageFile(const CString &endlessImgPath, ULONGLONG selectedGigs);
+	static bool ExtendImageFile(const CString &endlessImgPath, uint64_t bytes);
 	static bool UnpackBootComponents(const CString &bootFilesPathGz, const CString &bootFilesPath);
 	static bool CopyMultipleItems(const CString &fromPath, const CString &toPath);
 	static bool IsLegacyBIOSBoot();
@@ -467,7 +467,7 @@ private:
 
 	CComBSTR GetDownloadString(const RemoteImageEntry &imageEntry);
 
-	ULONGLONG GetNeededSpaceForDualBoot(int &neededGigs, bool *isBaseImage = NULL);
+	ULONGLONG GetNeededSpaceForDualBoot(bool *isBaseImage = NULL);
 
 	static const UINT m_uTaskbarBtnCreatedMsg;
 

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -467,7 +467,7 @@ private:
 
 	CComBSTR GetDownloadString(const RemoteImageEntry &imageEntry);
 
-	ULONGLONG GetNeededSpaceForDualBoot(bool *isBaseImage = NULL);
+	ULONGLONG GetNeededSpaceForDualBoot(ULONGLONG *downloadSize, bool *isBaseImage = NULL);
 
 	static const UINT m_uTaskbarBtnCreatedMsg;
 

--- a/src/endless/Log2LL.h
+++ b/src/endless/Log2LL.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <intrin.h>
+#pragma intrinsic(_BitScanReverse)
+
+#ifdef  _M_X64
+#  pragma intrinsic(_BitScanReverse64)
+#else
+static __forceinline unsigned char _BitScanReverse64(
+    unsigned long *Index,
+    unsigned __int64 Mask)
+{
+    LARGE_INTEGER s;
+    unsigned long i;
+
+    s.QuadPart = Mask;
+
+    if (_BitScanReverse(&i, s.HighPart)) {
+        *Index = i + 32;
+        return 1;
+    }
+
+    return _BitScanReverse(Index, s.LowPart);
+}
+#endif
+
+// Returns log2(x), rounded towards 0, or 0 if x is 0.
+static inline unsigned long log2ll(uint64_t x) {
+    unsigned long i = 0;
+
+    if (_BitScanReverse64(&i, x)) {
+        return i;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Previously we correctly showed an error if there wasn't enough space for the download + minimum unpacked image size + a gig of slack on C:; but the maximum size we offered was the entire disk free space, minus 1GiB.  If the user selected this option, the download would succeed, the image would be unpacked, and then extending the image would fail. Users would actually then be able to go back and install from the pre-downloaded image -- in which case the maximum size would be chosen correctly -- but let's avoid that happening at all.

Also includes a patch to simplify(?) calculating the values to show in the dropdown menu. All the best "simplification" patches include polyfill functions for x64 intrinsics.

https://phabricator.endlessm.com/T13351