### PR TITLE
Increase minimum free space for installation to 4GiB

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -3473,7 +3473,6 @@ ULONGLONG CEndlessUsbToolDlg::GetNeededSpaceForDualBoot(ULONGLONG *downloadSize,
 	if(isBaseImage != NULL)  *isBaseImage = true;
 	// figure out how much space we need
 	ULONGLONG neededSize = 0;
-	ULONGLONG bytesInGig = BYTES_IN_GIGABYTE;
 	if (m_useLocalFile) {
 		pFileImageEntry_t localEntry = NULL;
 
@@ -3494,7 +3493,8 @@ ULONGLONG CEndlessUsbToolDlg::GetNeededSpaceForDualBoot(ULONGLONG *downloadSize,
 			if (isBaseImage != NULL)  *isBaseImage = (remote.personality == PERSONALITY_BASE);
 		}
 	}
-	neededSize += bytesInGig;
+	const ULONGLONG paddingBytes = 4LL * BYTES_IN_GIGABYTE;
+	neededSize += paddingBytes;
 	return neededSize;
 }
 


### PR DESCRIPTION
Upgrading across major versions can require more than 1 GiB (the previous minimum free space); and in the 'base' image, installing any GNOME applications requires installing the GNOME runtime which is another gig or so. So: require more space to ensure users don't get stuck without the ability to upgrade.

Full images ship with the GNOME runtime, but if you have opted for a full image, you are less concerned about disk space, so for simplicity we add the same headroom.

This PR is on top of #88.

https://phabricator.endlessm.com/T17102