### PR TITLE
endless.loc: correct Mb, Gb -> MB, GB

### DIFF
--- a/po/rufus.pot
+++ b/po/rufus.pot
@@ -256,23 +256,23 @@ msgid "bytes"
 msgstr ""
 
 msgctxt "MSG_021"
-msgid "Kb"
+msgid "KB"
 msgstr ""
 
 msgctxt "MSG_022"
-msgid "Mb"
+msgid "MB"
 msgstr ""
 
 msgctxt "MSG_023"
-msgid "Gb"
+msgid "GB"
 msgstr ""
 
 msgctxt "MSG_024"
-msgid "Tb"
+msgid "TB"
 msgstr ""
 
 msgctxt "MSG_025"
-msgid "Pb"
+msgid "PB"
 msgstr ""
 
 #, c-format

--- a/src/endless/res/endless.loc
+++ b/src/endless/res/endless.loc
@@ -174,11 +174,11 @@ t USBLearnMore "Learn more about the Endless USB Stick"
 
 # *Short* size names. These can be used as suffixes
 t MSG_020 "bytes"
-t MSG_021 "Kb"
-t MSG_022 "Mb"
-t MSG_023 "Gb"
-t MSG_024 "Tb"
-t MSG_025 "Pb"
+t MSG_021 "KB"
+t MSG_022 "MB"
+t MSG_023 "GB"
+t MSG_024 "TB"
+t MSG_025 "PB"
 
 t MSG_045 "USB Storage Device (Generic)"
 # Used for USB drives that don't have a drive letter. Placeholders are:


### PR DESCRIPTION
Regardless of how one defines a gigabyte, the standard abbreviation is
"GB". "Gb" (or, more commonly, "Gbit") means "gigabit": 1 GB = 8 Gbit.

Note that while the IEC recommends that 1 kilobyte, when defined to mean
1000 bytes, should be spelled "1 kB" (with a lowercase "k"), Windows
uses "1 KB" (with an uppercase "K", meaning 1024 bytes). We follow this
convention here, as does Rufus upstream.

https://phabricator.endlessm.com/T12718