### PR TITLE
Don't show two errors if Windows < 7 and IE < 8

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -873,6 +873,7 @@ BOOL CEndlessUsbToolDlg::OnInitDialog()
     if (nWindowsVersion < WINDOWS_7) {
         ShowWindowsTooOldError();
         EndDialog(IDCANCEL);
+        return TRUE;
     }
 
     TrackEvent(_T("IEVersion"), m_ieVersion);


### PR DESCRIPTION
On a Windows Vista, IE 7 test VM, both error dialogs were displayed one after the other. Showing the IE error is misleading because updating IE will not help the user, and one of the buttons in the dialog sends them to Windows Update.

It also meant we would record the IEVersion event from unsupported Windows versions, messing up the stats.

https://phabricator.endlessm.com/T17064