### PR TITLE
Fix moving pages with normal vs. code titles

### DIFF
--- a/src/endless/res/EndlessUsbTool.css
+++ b/src/endless/res/EndlessUsbTool.css
@@ -218,7 +218,6 @@ select:disabled {
     border-bottom: 1px solid #a1a1a1;
 	border-radius: 8px 8px 0 0;
 	height: 34px;
-	cursor: move;
 	padding: 6px;
 	
 	font-size: medium;

--- a/src/endless/res/EndlessUsbTool.htm
+++ b/src/endless/res/EndlessUsbTool.htm
@@ -14,8 +14,8 @@
         <div id="DualBootInstallPage" class="WizardPage">
             <div class="PageHeader">
                 <div class="Button ButtonRight ButtonClose" id="DualBootPageCloseButton"></div>
-                <div id="DualBootPageTitle" class="PageHeaderTitle ModeNormal">Endless OS</div>
-                <div id="DualBootPageTitleCoding" class="PageHeaderTitle ModeCoding">Endless Coding</div>
+                <div class="ModeNormal"><div id="DualBootPageTitle" class="PageHeaderTitle">Endless OS</div></div>
+                <div class="ModeCoding"><div id="DualBootPageTitleCoding" class="PageHeaderTitle">Endless Coding</div></div>
             </div>
 
             <div class="FullWidthContent PageContent">
@@ -107,8 +107,8 @@
             <div class="PageHeader">
                 <div class="Button"><div id="SelectFilePreviousButton">Previous</div></div>
                 <div class="Button ButtonBlue ButtonRight" id="SelectFileNextButtonC"><div id="SelectFileNextButton">Next</div></div>
-                <div class="PageHeaderTitle ModeNormal" id="SelectFilePageTitle">Select Your Endless OS Version</div>
-                <div class="PageHeaderTitle ModeCoding" id="SelectFilePageTitleCoding">Select Your Endless Code Version</div>
+                <div class="ModeNormal"><div class="PageHeaderTitle" id="SelectFilePageTitle">Select Your Endless OS Version</div></div>
+                <div class="ModeCoding"><div class="PageHeaderTitle" id="SelectFilePageTitleCoding">Select Your Endless Code Version</div></div>
             </div>
 
             <div class="PageContent">
@@ -221,8 +221,8 @@
             <div class="PageHeader">
                 <div class="Button"><div id="SelectStoragePreviousButton">Previous</div></div>
                 <div id="SelectStorageNextButtonC" class="Button ButtonBlue ButtonRight"><div id="SelectStorageNextButton">Next</div></div>
-                <div class="PageHeaderTitle ModeNormal" id="SelectStoragePageTitle">Storage Space for Endless OS</div>
-                <div class="PageHeaderTitle ModeCoding" id="SelectStoragePageTitleCoding">Storage Space for Endless Code</div>
+                <div class="ModeNormal"><div class="PageHeaderTitle" id="SelectStoragePageTitle">Storage Space for Endless OS</div></div>
+                <div class="ModeCoding"><div class="PageHeaderTitle" id="SelectStoragePageTitleCoding">Storage Space for Endless Code</div></div>
             </div>
 
             <div class="PageContent">
@@ -262,8 +262,8 @@
         <div id="InstallingPage" class="WizardPage hidden">
             <div class="PageHeader">
 				<div id="InstallCancelButtonC" class="Button ButtonRight"><div id="InstallCancelButton">Cancel</div></div>
-                <div class="PageHeaderTitle ModeNormal" id="InstallingPageTitle">Installing</div>
-                <div class="PageHeaderTitle ModeCoding" id="InstallingPageTitleCoding">Installing</div>
+                <div class="ModeNormal"><div class="PageHeaderTitle" id="InstallingPageTitle">Installing</div></div>
+                <div class="ModeCoding"><div class="PageHeaderTitle" id="InstallingPageTitleCoding">Installing</div></div>
             </div>
 
             <div class="PageContent">


### PR DESCRIPTION
To allow the user to drag the dialog around the screen by its "titlebar", `mousedown` events on elements with class 'PageHeader' or `PageHeaderTitle` are caught and converted into 'WM_NCLBUTTONDOWN' messages.  The mousedown events are bound to a method using the 'DHTML_EVENT_CLASS' macro.  Apparently this is implemented in terms of matching the entire class name, not individual elements of the space-separated class list, so an element with `class="PageHeaderTitle ModeNormal"` is not matched by `DHTML_EVENT_CLASS(..., L"PageHeaderTitle", ...)'.

So, instead, wrap the `PageHeaderTitle` elements in an extra `<div>` just to carry the `ModeNormal`/`ModeCoding` class. I tried the opposite way round:

    <div class="PageHeaderTitle">
       <div class="ModeNormal" id="DualBootPageTitle">Endless OS</div>
       <div class="ModeCoding" id="DualBootPageTitleCoding">Endless Coding</div>
    </div>

which looks neater, but also doesn't work, presumably because the event is fired at the inner element rather than the wrapper `.PageHeaderTitle` element. In modern browsers you can use `style="pointer-events: none;"` to make an element transparent to clicks but this is not supported on most of the IE versions we support.

(Also a patch to fix a pet peeve of mine.)

https://phabricator.endlessm.com/T14033