### PR TITLE
Use normal mouse pointer, not I-bar, on titlebars

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 # most Rufus code uses tabs
 [*]
 indent_style = tab
+insert_final_newline = false
 
 # Endless code is an unholy mixture. Err on the side of spaces, but set
 # unambiguously-tabby files to keep with tabs for now.

--- a/src/endless/res/EndlessUsbTool.css
+++ b/src/endless/res/EndlessUsbTool.css
@@ -218,6 +218,7 @@ select:disabled {
     border-bottom: 1px solid #a1a1a1;
 	border-radius: 8px 8px 0 0;
 	height: 34px;
+	cursor: default;
 	padding: 6px;
 	
 	font-size: medium;


### PR DESCRIPTION
This was a regression in f429c67. The + was "goofy", but not specifying the cursor used means we get an I-bar when hovering over text. The confusingly-named "default" cursor is the "normal" cursor you'd expect; "auto" is the CSS default and lets the browser decide.

Also: an `.editorconfig` tweak.