### PR TITLE
Fetch eos3.2 boot.zip when installing eos3.1 image

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -2645,7 +2645,7 @@ static bool FindLatestVersion(const Json::Value &rootValue, Json::Value &latestE
 
         const char *versionString = (*it)[JSON_IMG_VERSION].asCString();
         ImageVersion currentParsedVersion;
-        if (!ImageVersion::Parse(versionString, currentParsedVersion)) {
+        if (!ParseImageVersion(versionString, currentParsedVersion)) {
             uprintf("Can't parse version '%s'", versionString);
             continue;
         }

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -452,6 +452,7 @@ private:
 	static void DelayDeleteFolder(const CString &folder);
 
 	static bool HasImageBootSupport(const CString &version, const CString &date);
+	static bool HasEosldr(const CString &version);
 
 	bool PackedImageAlreadyExists(const CString &filePath, ULONGLONG expectedSize, ULONGLONG expectedUnpackedSize, bool isInstaller);
 

--- a/src/endless/Images.cpp
+++ b/src/endless/Images.cpp
@@ -11,7 +11,7 @@
 #define EOS_OEM_PRODUCT_TEXT        "eosoem"
 #define EOS_RETAIL_PRODUCT_TEXT     "eosretail"
 
-bool ImageVersion::Parse(const char *str, ImageVersion &ret)
+bool ParseImageVersion(const char *str, ImageVersion &ret)
 {
     char *s = (char *)str;
     char *end = NULL;

--- a/src/endless/Images.h
+++ b/src/endless/Images.h
@@ -13,9 +13,7 @@
 #define EXFAT_ENDLESS_LIVE_FILE_NAME    L"live"
 
 // vectors have lexicographic ordering! Hooray
-class ImageVersion : public std::vector<uint32_t> {
-public:
-    static bool Parse(const char *str, ImageVersion &ret);
-};
+typedef std::vector<uint32_t> ImageVersion;
+bool ParseImageVersion(const char *str, ImageVersion &ret);
 
 bool ParseImgFileName(const CString& filename, CString &personality, CString &version, CString &date, bool &isInstallerImage);

--- a/src/endless/res/EndlessUsbTool.css
+++ b/src/endless/res/EndlessUsbTool.css
@@ -821,13 +821,23 @@ select:disabled {
 
 
 #VersionContainer {
+	position: absolute;
+	right: 5px;
+	bottom: 10px;
+
 	font-size: 9px;
 	text-align: right;
-	padding-right: 5px;
-	padding-top: 10px;
 }
 
 #VersionContainer, #VersionContainer a {
 	color: #d6d6d6;
 	text-decoration: none;
+}
+
+#VersionContainer a {
+	padding: 5px;
+}
+
+#VersionContainer a:hover {
+	color: #5f9ddd;
 }


### PR DESCRIPTION
To use eosldr, there's actually no hard dependency on an Endless OS 3.2 image: you just need a new enough boot.zip. So we can enable installing released versions of the OS, booting with Windows Boot Manager and eosldr, by fetching a newer boot.zip as needed.

https://phabricator.endlessm.com/T17244