### PR TITLE
Ensure installed OS image is a multiple of 512 bytes

### DIFF
--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -468,6 +468,7 @@ private:
 
 	CComBSTR GetDownloadString(const RemoteImageEntry &imageEntry);
 
+	static ULONGLONG RoundToSector(ULONGLONG size);
 	ULONGLONG GetNeededSpaceForDualBoot(ULONGLONG *downloadSize, bool *isBaseImage = NULL);
 
 	static const UINT m_uTaskbarBtnCreatedMsg;


### PR DESCRIPTION
All extents of the image must be a multiple of 512 bytes long to be fed to device-mapper. NTFS's sector size is (typically) 4096 bytes so that's generally okay, but if the total size is not a multiple of 512 the last chunk may not be a suitable length, and Endless OS won't boot. Just round up if needed.

This bug was introduced in 674ed7d. Previously, all sizes were rounded down to the nearest 1GiB, which is a multiple of 512.

We only need to explicitly round the minimum and maximum sizes offered.  All other sizes offered are powers of 2 greater than 512 so are divisible by 512 (2⁹).

https://phabricator.endlessm.com/T17567