### PR TITLE
Report {Download,Verify}Finished events

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -3829,6 +3829,19 @@ void CEndlessUsbToolDlg::UpdateCurrentStep(int currentStep)
 
     FUNCTION_ENTER;
 
+    switch (m_currentStep)
+    {
+    case OP_DOWNLOADING_FILES:
+        TrackEvent(_T("DownloadFinished"));
+        break;
+    case OP_VERIFYING_SIGNATURE:
+        TrackEvent(_T("VerifyFinished"));
+        break;
+    default:
+        // Otherwise, nothing to report.
+        break;
+    }
+
     int nrSteps = m_useLocalFile ? 2 : 3;
     CString action;
     int nrCurrentStep;


### PR DESCRIPTION
UpdateCurrentStep is only called on the happy path. This should allow us to more clearly understand at what point users are cancelling or hitting errors. In particular, while we'd expect COUNT(VerifyFinished) = COUNT(InstallStarted) + COUNT(WritingStarted), if users already have a copy of the image file, they will skip the DownloadStarted/DownloadFinished pair.

https://phabricator.endlessm.com/T13810