### PR TITLE
Treat DISK_FULL as a fatal error, improve message.

### DIFF
--- a/po/rufus.pot
+++ b/po/rufus.pot
@@ -491,9 +491,12 @@ msgctxt "MSG_333"
 msgid "Your USB 3.0 device is inserted into a USB 2.0 port. Please insert it into a USB 3.0 port (usually blue) for the best experience."
 msgstr ""
 
+#. Placeholders are:
+#. 1. drive (such as "C:\")
+#. 2. amount of space needed (eg "4.7GB")
 #, c-format
 msgctxt "MSG_334"
-msgid "There isn’t enough disk space for downloading Endless OS. Please free up %s and click \"Resume\" to start downloading."
+msgid "There isn’t enough disk space on %s for downloading Endless OS. Please free up %s and click “Resume” to start downloading."
 msgstr ""
 
 #, c-format

--- a/src/endless/DownloadManager.h
+++ b/src/endless/DownloadManager.h
@@ -81,6 +81,8 @@ public:
 
 private:
     void ReportStatus(const DownloadStatus_t &downloadStatus);
+    static void PopulateErrorDetails(DownloadStatus_t &downloadStatus, IBackgroundCopyError *pError);
+    static void PopulateErrorDetails(DownloadStatus_t &downloadStatus, IBackgroundCopyJob *pJob);
 
     LONG m_PendingJobModificationCount;
     static volatile ULONG m_refCount;

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -1798,6 +1798,8 @@ void CEndlessUsbToolDlg::ErrorOccured(ErrorCause_t errorCause)
         CComBSTR message;
         if (suggestionMsgId == MSG_334 || suggestionMsgId == MSG_303) {
             // Not enough space to download
+            const CStringA downloadDriveA = ConvertUnicodeToUTF8(CEndlessUsbToolApp::m_imageDir.Left(3));
+
             POSITION p = m_remoteImages.FindIndex(m_selectedRemoteIndex);
             ULONGLONG size = 0;
             if (p != NULL) {
@@ -1806,7 +1808,7 @@ void CEndlessUsbToolDlg::ErrorOccured(ErrorCause_t errorCause)
             }
             // we don't take the signature files into account but we are taking about ~2KB compared to >2GB
             ULONGLONG totalSize = size + (m_selectedInstallMethod == InstallMethod_t::ReformatterUsb ? m_installerImage.compressedSize : 0);
-            message = UTF8ToBSTR(lmprintf(suggestionMsgId, SizeToHumanReadable(totalSize, FALSE, use_fake_units)));
+            message = UTF8ToBSTR(lmprintf(suggestionMsgId, downloadDriveA, SizeToHumanReadable(totalSize, FALSE, use_fake_units)));
         } else if(suggestionMsgId == MSG_351 || suggestionMsgId == MSG_301) {
             // Not enough space to install (either our size logic is buggy, or
             // the user downloaded some other huge file between choosing a size

--- a/src/endless/res/endless.loc
+++ b/src/endless/res/endless.loc
@@ -280,8 +280,11 @@ t MSG_331 "You have selected a slow USB device (USB 1.0). Please use a USB 2.0 d
 t MSG_332 "You have selected a slower USB device (USB 2.0). Please use a USB 3.0 device for the best experience."
 t MSG_333 "Your USB 3.0 device is inserted into a USB 2.0 port. Please insert it into a USB 3.0 port (usually blue) for the best experience."
 
-t MSG_334 "There isn’t enough disk space for downloading Endless OS. Please free up %s and click \"Resume\" to start downloading."
-t MSG_303 "There isn’t enough disk space for downloading Endless Code. Please free up %s and click \"Resume\" to start downloading."
+# Placeholders are:
+# 1. drive (such as "C:\")
+# 2. amount of space needed (eg "4.7GB")
+t MSG_334 "There isn’t enough disk space on %s for downloading Endless OS. Please free up %s and click “Resume” to start downloading."
+t MSG_303 "There isn’t enough disk space on %s for downloading Endless Code. Please free up %s and click “Resume” to start downloading."
 
 t MSG_335 "The selected version of Endless OS requires %s of free disk space, but only %s is available. Please free up some space on drive %s to continue."
 t MSG_374 "The selected version of Endless Code requires %s of free disk space, but only %s is available. Please free up some space on drive %s to continue."


### PR DESCRIPTION
Without this, when the disk is full the download just appears to get stuck at 0%.

This was previously fixed in 386e536 by just treating all TRANSIENT_ERRORs as ERRORs, but e921aed removed this change since it meant that truly transient conditions, like "the internet connection temporarily flapped", were treated as fatal.

I also fixed the error message, as requested the last time this bug was fixed. :-)

Tested by attempting to download the en image in my VM which doesn't have enough disk space (it failed), trying to download the base image, and manually taking the network connection down and up (no regression), and launching the app with no network connection (no regression: the JSON file was fetched when I brought the connection back up).

https://phabricator.endlessm.com/T11935