### PR TITLE
appveyor: cache upx.exe, update it

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,13 @@ configuration:
   - Release
 
 install:
-  - appveyor DownloadFile https://github.com/upx/upx/releases/download/v3.91/upx391w.zip -FileName upx.zip
-  - 7z e upx.zip *.exe -r
+  - if not exist upx.exe (
+        appveyor DownloadFile https://github.com/upx/upx/releases/download/v3.91/upx391w.zip -FileName upx.zip &&
+        7z e upx.zip *.exe -r
+    )
+
+cache:
+  - C:\projects\rufus\upx.exe -> appveyor.yml
 
 # We assume tags are of the form VERSION_foo, and we assume that foo matches
 # the version number embedded in the executable.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ configuration:
 
 install:
   - if not exist upx.exe (
-        appveyor DownloadFile https://github.com/upx/upx/releases/download/v3.91/upx391w.zip -FileName upx.zip &&
+        appveyor DownloadFile https://github.com/upx/upx/releases/download/v3.94/upx394w.zip -FileName upx.zip &&
         7z e upx.zip *.exe -r
     )
 


### PR DESCRIPTION
You can see from this build https://ci.appveyor.com/project/Endless/rufus/build/787-T13352/job/wiaoy963dlw8atnr that upx.exe is restored from cache.

https://phabricator.endlessm.com/T13352