### PR TITLE
Refactor and improve CreateUSBStick

### DIFF
--- a/src/drive.c
+++ b/src/drive.c
@@ -889,8 +889,10 @@ BOOL MountVolume(char* drive_name, char *drive_guid)
 }
 
 /*
- * Mount partition #part_nr, residing on the same disk as drive_name to an available
- * drive letter. Returns the newly allocated drive string.
+ * Mount partition #part_nr, residing on the same disk as drive_name (which must be
+ * of the form "X:" with no trailing slash) to an available
+ * drive letter. Returns a borrowed pointer to the newly-allocated drive letter of
+ * the form "Y:", which must not be freed, or NULL on error.
  * We need to do this because, for instance, EFI System partitions are not assigned
  * Volume GUIDs by the OS, and we need to have a letter assigned, for when we invoke
  * bcdtool for Windows To Go. All in all, the process looks like this:

--- a/src/drive.c
+++ b/src/drive.c
@@ -889,6 +889,58 @@ BOOL MountVolume(char* drive_name, char *drive_guid)
 }
 
 /*
+ * Mount the volume identified by drive_guid on a drive letter, if it is not already, and return the mount point in drive_guid.
+ * drive_guid should be initialized to "?:\"; the first character will be overwritten with the mounted drive letter.
+ */
+BOOL EnsureVolumeMounted(char* drive_name, char *drive_guid)
+{
+	char mounted_guid[52];	// You need at least 51 characters on XP
+	char mounted_letter[16] = {0};
+	DWORD size;
+
+	if (drive_name[0] != '?')
+		return FALSE;
+
+	// For fixed disks, Windows may already have remounted the volume.
+	if ( (GetVolumePathNamesForVolumeNameA(drive_guid, mounted_letter, sizeof(mounted_letter), &size))
+	  && (size > 1) ) {
+		uprintf("Volume is already mounted at %c", mounted_letter[0]);
+		drive_name[0] = mounted_letter[0];
+		return TRUE;
+	}
+
+	drive_name[0] = GetUnusedDriveLetter();
+	if (drive_name[0] == 0) {
+		uprintf("Could not find an unused drive letter");
+		return FALSE;
+	}
+
+	if (SetVolumeMountPointA(drive_name, drive_guid)) {
+		uprintf("%s mounted as %s", drive_guid, drive_name);
+		return TRUE;
+	} else {
+		// If the OS mounted something on that letter in parallel, this operation can fail
+		// with ERROR_DIR_NOT_EMPTY. If that's the case, just check that mountpoints match
+		if (GetLastError() == ERROR_DIR_NOT_EMPTY) {
+			if (!GetVolumeNameForVolumeMountPointA(drive_name, mounted_guid, sizeof(mounted_guid))) {
+				uprintf("%s already mounted, but volume GUID could not be checked: %s",
+					drive_name, WindowsErrorString());
+				return FALSE;
+			}
+			if (safe_strcmp(drive_guid, mounted_guid) != 0) {
+				uprintf("%s already mounted, but volume GUID doesn't match. Hoped for %s, got %s",
+					drive_name, drive_guid, mounted_guid);
+				return FALSE;
+			}
+			uprintf("%s was already mounted as %s\n", drive_guid, drive_name);
+			return TRUE;
+		} else {
+			return FALSE;
+		}
+	}
+}
+
+/*
  * Mount partition #part_nr, residing on the same disk as drive_name (which must be
  * of the form "X:" with no trailing slash) to an available
  * drive letter. Returns a borrowed pointer to the newly-allocated drive letter of

--- a/src/drive.h
+++ b/src/drive.h
@@ -93,6 +93,7 @@ BOOL AnalyzePBR(HANDLE hLogicalVolume);
 BOOL GetDrivePartitionData(DWORD DriveIndex, char* FileSystemName, DWORD FileSystemNameSize, BOOL bSilent);
 BOOL UnmountVolume(HANDLE hDrive);
 BOOL MountVolume(char* drive_name, char *drive_guid);
+BOOL EnsureVolumeMounted(char* drive_name, char *drive_guid);
 BOOL AltUnmountVolume(const char* drive_name);
 char* AltMountVolume(const char* drive_name, uint8_t part_nr);
 BOOL RemountVolume(char* drive_name);

--- a/src/endless/EndlessUsbTool.vcxproj
+++ b/src/endless/EndlessUsbTool.vcxproj
@@ -290,6 +290,7 @@
     <ClInclude Include="grub\grub.h" />
     <ClInclude Include="grub\reed_solomon.h" />
     <ClInclude Include="Images.h" />
+    <ClInclude Include="IOUtil.h" />
     <ClInclude Include="json\json-forwards.h" />
     <ClInclude Include="json\json.h" />
     <ClInclude Include="localization_data.h" />
@@ -514,6 +515,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="Images.cpp" />
+    <ClCompile Include="IOUtil.cpp" />
     <ClCompile Include="StringHelperMethods.cpp" />
     <ClCompile Include="jsoncpp.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>

--- a/src/endless/EndlessUsbTool.vcxproj
+++ b/src/endless/EndlessUsbTool.vcxproj
@@ -271,6 +271,7 @@
   <ItemGroup>
     <ClInclude Include="..\dos.h" />
     <ClInclude Include="..\drive.h" />
+    <ClInclude Include="..\format.h" />
     <ClInclude Include="..\localization.h" />
     <ClInclude Include="..\msapi_utf8.h" />
     <ClInclude Include="..\rufus.h" />

--- a/src/endless/EndlessUsbTool.vcxproj.filters
+++ b/src/endless/EndlessUsbTool.vcxproj.filters
@@ -90,6 +90,9 @@
     <ClInclude Include="..\dos.h">
       <Filter>Header Files\Rufus Headers</Filter>
     </ClInclude>
+    <ClInclude Include="..\format.h">
+      <Filter>Header Files\Rufus Headers</Filter>
+    </ClInclude>
     <ClInclude Include="DownloadManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/src/endless/EndlessUsbTool.vcxproj.filters
+++ b/src/endless/EndlessUsbTool.vcxproj.filters
@@ -156,6 +156,9 @@
     <ClInclude Include="UEFIBootSetup.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="IOUtil.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="EndlessUsbTool.cpp">
@@ -258,6 +261,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Eosldr.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="IOUtil.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -1395,6 +1395,9 @@ LRESULT CEndlessUsbToolDlg::WindowProc(UINT message, WPARAM wParam, LPARAM lPara
             BOOL result = (BOOL)wParam;
             m_operationThread = INVALID_HANDLE_VALUE;
             if (result) {
+                IFFALSE_PRINTERROR(SetFormatPromptHook(),
+                    "Could not set 'Format Disk' prompt auto-close");
+
                 if (IsDualBootOrCombinedUsb()) {
                     m_cancelImageUnpack = 0;
                     if (m_selectedInstallMethod == InstallMethod_t::CombinedUsb) {
@@ -1437,6 +1440,7 @@ LRESULT CEndlessUsbToolDlg::WindowProc(UINT message, WPARAM wParam, LPARAM lPara
             m_operationThread = INVALID_HANDLE_VALUE;
             m_currentStep = OP_NO_OPERATION_IN_PROGRESS;
 
+            ClrFormatPromptHook();
             EnableHibernate();
 
 			if (m_selectedInstallMethod != InstallMethod_t::InstallDualBoot) ChangeDriveAutoRunAndMount(false);

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -4102,7 +4102,7 @@ DWORD WINAPI CEndlessUsbToolDlg::FileCopyThread(void* param)
     FUNCTION_ENTER;
 
     CEndlessUsbToolDlg *dlg = (CEndlessUsbToolDlg*)param;
-    
+
     HANDLE hPhysical = INVALID_HANDLE_VALUE;
     DWORD size;
     DWORD DriveIndex = SelectedDrive.DeviceNumber;
@@ -4114,19 +4114,19 @@ DWORD WINAPI CEndlessUsbToolDlg::FileCopyThread(void* param)
     CString driveDestination, fileDestination, liveFileName;
     CStringA driveDestinationA, iniLanguage = INI_LOCALE_EN;
 
-	// Radu: why do we do this?
+    // Radu: why do we do this?
     memset(&SelectedDrive, 0, sizeof(SelectedDrive));
 
     // Query for disk and partition data
     hPhysical = GetPhysicalHandle(DriveIndex, TRUE, TRUE);
     IFFALSE_GOTOERROR(hPhysical != INVALID_HANDLE_VALUE, "Error on acquiring disk handle.");
-    
+
     result = DeviceIoControl(hPhysical, IOCTL_DISK_GET_DRIVE_GEOMETRY_EX, NULL, 0, geometry, sizeof(geometry), &size, NULL);
     IFFALSE_GOTOERROR(result != 0 && size > 0, "Error on querying disk geometry.");
 
     result = DeviceIoControl(hPhysical, IOCTL_DISK_GET_DRIVE_LAYOUT_EX, NULL, 0, layout, sizeof(layout), &size, NULL);
     IFFALSE_GOTOERROR(result != 0 && size > 0, "Error on querying disk layout.");
-    
+
     IFFALSE_GOTOERROR(DriveLayout->PartitionStyle == PARTITION_STYLE_GPT, "Unexpected partition type.");
     IFFALSE_GOTOERROR(DriveLayout->PartitionCount == EXPECTED_NUMBER_OF_PARTITIONS, "Error: Unexpected number of partitions.");
 
@@ -4162,19 +4162,19 @@ DWORD WINAPI CEndlessUsbToolDlg::FileCopyThread(void* param)
 
     // Check if user cancelled
     IFFALSE_GOTOERROR(WaitForSingleObject(dlg->m_cancelOperationEvent, 0) == WAIT_TIMEOUT, "User cancel.");
-	// Format the partition
-	IFFALSE_GOTOERROR(FormatFirstPartitionOnDrive(DriveIndex, L"exFAT", EXFAT_CLUSTER_SIZE, dlg->m_cancelOperationEvent, EXFAT_PARTITION_NAME_IMAGES), "Error on FormatFirstPartitionOnDrive");
+    // Format the partition
+    IFFALSE_GOTOERROR(FormatFirstPartitionOnDrive(DriveIndex, L"exFAT", EXFAT_CLUSTER_SIZE, dlg->m_cancelOperationEvent, EXFAT_PARTITION_NAME_IMAGES), "Error on FormatFirstPartitionOnDrive");
     // Mount it
-	IFFALSE_GOTOERROR(MountFirstPartitionOnDrive(DriveIndex, driveDestinationA), "Error on MountFirstPartitionOnDrive");
+    IFFALSE_GOTOERROR(MountFirstPartitionOnDrive(DriveIndex, driveDestinationA), "Error on MountFirstPartitionOnDrive");
     driveDestination = driveDestinationA;
 
     // Copy Files
-	liveFileName = CSTRING_GET_LAST(dlg->m_localFile, L'\\');
-	if (liveFileName == ENDLESS_IMG_FILE_NAME) {
-		fileDestination = driveDestination + CSTRING_GET_PATH(CSTRING_GET_LAST(dlg->m_localFileSig, L'\\'), L'.');
-	} else {
-		fileDestination = driveDestination + liveFileName;
-	}
+    liveFileName = CSTRING_GET_LAST(dlg->m_localFile, L'\\');
+    if (liveFileName == ENDLESS_IMG_FILE_NAME) {
+        fileDestination = driveDestination + CSTRING_GET_PATH(CSTRING_GET_LAST(dlg->m_localFileSig, L'\\'), L'.');
+    } else {
+        fileDestination = driveDestination + liveFileName;
+    }
     result = CopyFileEx(dlg->m_localFile, fileDestination, CEndlessUsbToolDlg::CopyProgressRoutine, dlg, NULL, 0);
     IFFALSE_GOTOERROR(result, "Copying live image failed/cancelled.");
 

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -1857,8 +1857,8 @@ void CEndlessUsbToolDlg::ErrorOccured(ErrorCause_t errorCause)
     SetElementText(_T(ELEMENT_ERROR_DELETE_TEXT), deleteFilesText);
 
     // Update the error description and "recovery" suggestion
+    CComBSTR message("");
     if (suggestionMsgId != 0) {
-        CComBSTR message;
         if (suggestionMsgId == MSG_334 || suggestionMsgId == MSG_303) {
             // Not enough space to download
             const CStringA downloadDriveA = ConvertUnicodeToUTF8(CEndlessUsbToolApp::m_imageDir.Left(3));
@@ -1883,8 +1883,8 @@ void CEndlessUsbToolDlg::ErrorOccured(ErrorCause_t errorCause)
         } else {
             message = UTF8ToBSTR(lmprintf(suggestionMsgId));
         }
-        SetElementText(_T(ELEMENT_ERROR_SUGGESTION), message);
     }
+    SetElementText(_T(ELEMENT_ERROR_SUGGESTION), message);
 
 	if (m_taskbarProgress != NULL) {
 		m_taskbarProgress->SetProgressState(m_hWnd, TBPF_ERROR);

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -1898,17 +1898,7 @@ void CEndlessUsbToolDlg::ErrorOccured(ErrorCause_t errorCause)
 	else
 		TrackEvent(_T("Failed"), ErrorCauseToStr(errorCause));
 
-	bool fatal = FALSE;
-	switch (errorCause) {
-	case ErrorCause_t::ErrorCauseDownloadFailed:
-	case ErrorCause_t::ErrorCauseVerificationFailed:
-	case ErrorCause_t::ErrorCauseWriteFailed:
-		fatal = FALSE;
-		break;
-	default:
-		fatal = TRUE;
-		break;
-	}
+	bool fatal = recoverButtonMsgId == 0;
 	Analytics::instance()->exceptionTracking(ErrorCauseToStr(errorCause), fatal);
 }
 

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -4915,17 +4915,21 @@ bool CEndlessUsbToolDlg::FormatFirstPartitionOnDrive(DWORD DriveIndex, const wch
 	BOOL result;
 	int formatRetries = 5;
 	bool returnValue = false;
+	char *name = NULL;
 
 	// Wait for the logical drive we just created to appear
 	uprintf("Waiting for logical drive to reappear...\n");
 	Sleep(200); // Radu: check if this is needed, that's what rufus does; I hate sync using sleep
 	IFFALSE_PRINTERROR(WaitForLogical(DriveIndex), "Warning: Logical drive was not found!"); // We try to continue even if this fails, just in case
 
+	name = GetLogicalName(DriveIndex, FALSE, TRUE);
+	IFFALSE_GOTOERROR(name != NULL, "GetLogicalName failed");
+
 	while (formatRetries-- > 0) {
 		// Clear any leftover error state
 		FormatStatus = 0;
 
-		if ((result = FormatPartition(DriveIndex, wFSType, wPartLabel, ulClusterSize))) {
+		if ((result = FormatPartition(name, wFSType, wPartLabel, ulClusterSize))) {
 			break;
 		}
 
@@ -4944,6 +4948,7 @@ bool CEndlessUsbToolDlg::FormatFirstPartitionOnDrive(DWORD DriveIndex, const wch
 error:
 	safe_free(wFSType);
 	safe_free(wPartLabel);
+	safe_free(name);
 	return returnValue;
 }
 

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -5018,9 +5018,8 @@ bool CEndlessUsbToolDlg::MountFirstPartitionOnDrive(DWORD DriveIndex, CStringA &
 
 	// Mount partition
 	char drive_name[] = "?:\\";
-	drive_name[0] = GetUnusedDriveLetter();
-	IFFALSE_GOTOERROR(drive_name[0] != 0, "Could not find an unused drive letter");
-	IFFALSE_GOTOERROR(MountVolume(drive_name, guid_volume), "Could not mount volume.");
+	IFFALSE_GOTOERROR(EnsureVolumeMounted(drive_name, guid_volume), "Could not mount volume.");
+	IFFALSE_GOTOERROR(drive_name[0] != 0, "EnsureVolumeMounted succeeded but did not return a drive name...");
 	driveLetter = drive_name;
 
 	returnValue = true;

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -1717,6 +1717,9 @@ void CEndlessUsbToolDlg::ErrorOccured(ErrorCause_t errorCause)
     uint32_t recoverButtonMsgId = 0, suggestionMsgId = 0, headlineMsgId = IsCoding() ? MSG_381 : MSG_370;
     bool driveLetterInHeading = false;
 
+// Require all error causes to be handled
+#pragma warning( push )
+#pragma warning( error : 4061 )
     switch (errorCause) {
     case ErrorCause_t::ErrorCauseDownloadFailed:
         recoverButtonMsgId = MSG_RECOVER_RESUME;
@@ -1740,6 +1743,8 @@ void CEndlessUsbToolDlg::ErrorOccured(ErrorCause_t errorCause)
     case ErrorCause_t::ErrorCauseGeneric:
     case ErrorCause_t::ErrorCauseWriteFailed:
     case ErrorCause_t::ErrorCauseSuspended: // TODO: new string here
+    case ErrorCause_t::ErrorCauseCantUnpackBootZip:
+    case ErrorCause_t::ErrorCauseInstallEosldrFailed:
         recoverButtonMsgId = MSG_RECOVER_TRY_AGAIN;
         suggestionMsgId = m_selectedInstallMethod == InstallMethod_t::InstallDualBoot
 	    ? (IsCoding() ? MSG_385 : MSG_358)
@@ -1768,10 +1773,16 @@ void CEndlessUsbToolDlg::ErrorOccured(ErrorCause_t errorCause)
         // TODO: new string here; or, better, eliminate this failure mode
         suggestionMsgId = MSG_358;
         break;
+    case ErrorCause_t::ErrorCauseNonEndlessMBR:
+    case ErrorCause_t::ErrorCauseUninstallEosldrFailed:
+        uprintf("Uninstall-specific error cause %ls", ErrorCauseToStr(errorCause));
+        break;
+    case ErrorCause_t::ErrorCauseNone:
     default:
         uprintf("Unhandled error cause %ls(%d)", ErrorCauseToStr(errorCause), errorCause);
         break;
     }
+#pragma warning( pop )
 
     // Update the error button text if it's a "recoverable" error case or hide it otherwise
     if (recoverButtonMsgId != 0) {

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -399,10 +399,10 @@ private:
 	void ChangeDriveAutoRunAndMount(bool setEndlessValues);
 
 	static DWORD WINAPI CreateUSBStick(LPVOID param);
-	static bool CreateFakePartitionLayout(HANDLE hPhysical, PBYTE layout, PBYTE geometry);
+	static bool CreateUSBPartitionLayout(HANDLE hPhysical, DWORD &BytesPerSector);
 	static bool FormatFirstPartitionOnDrive(DWORD DriveIndex, const wchar_t *kFSType, ULONG ulClusterSize, HANDLE cancelEvent, const wchar_t *kPartLabel);
-	static bool MountFirstPartitionOnDrive(DWORD DriveIndex, CString &driveLetter);
-	static bool CreateCorrectPartitionLayout(HANDLE hPhysical, PBYTE layout, PBYTE geometry);
+	static bool FormatPartitionWithRetry(const char *partition, const wchar_t *kFSType, ULONG ulClusterSize, HANDLE cancelEvent, const wchar_t *kPartLabel);
+	static bool MountFirstPartitionOnDrive(DWORD DriveIndex, CStringA &driveLetter);
 
 	static bool UnpackZip(const CComBSTR source, const CComBSTR dest);
 	static void RemoveNonEmptyDirectory(const CString directoryPath);

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -62,6 +62,18 @@ typedef enum ErrorCause {
     ErrorCauseInstallEosldrFailed,
     ErrorCauseUninstallEosldrFailed,
     ErrorCauseCantUnpackBootZip,
+    ErrorCauseGetPhysicalHandleFailed,
+    ErrorCauseDisappearingExistingVolumesFailed,
+    ErrorCauseErasePartitionsFailed,
+    ErrorCauseWriteBiosBootFailed,
+    ErrorCauseCreatePartitionsFailed,
+    ErrorCauseWriteMBRFailed,
+    ErrorCauseFormatExfatFailed,
+    ErrorCauseMountExfatFailed,
+    ErrorCauseMountESPFailed,
+    ErrorCauseFormatESPFailed,
+    ErrorCausePopulateESPFailed,
+    ErrorCausePopulateExfatFailed,
 } ErrorCause_t;
 
 typedef struct RemoteImageEntry {

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -399,6 +399,7 @@ private:
 	void ChangeDriveAutoRunAndMount(bool setEndlessValues);
 
 	static DWORD WINAPI CreateUSBStick(LPVOID param);
+	static bool DeleteMountpointsForDrive(DWORD DriveIndex);
 	static bool CreateUSBPartitionLayout(HANDLE hPhysical, DWORD &BytesPerSector);
 	static bool FormatFirstPartitionOnDrive(DWORD DriveIndex, const wchar_t *kFSType, ULONG ulClusterSize, HANDLE cancelEvent, const wchar_t *kPartLabel);
 	static bool FormatPartitionWithRetry(const char *partition, const wchar_t *kFSType, ULONG ulClusterSize, HANDLE cancelEvent, const wchar_t *kPartLabel);

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -400,7 +400,7 @@ private:
 
 	static DWORD WINAPI CreateUSBStick(LPVOID param);
 	static bool CreateFakePartitionLayout(HANDLE hPhysical, PBYTE layout, PBYTE geometry);
-	static bool FormatFirstPartitionOnDrive(DWORD DriveIndex, int fsToUse, HANDLE m_cancelOperationEvent, const wchar_t *partLabel);
+	static bool FormatFirstPartitionOnDrive(DWORD DriveIndex, const wchar_t *kFSType, ULONG ulClusterSize, HANDLE cancelEvent, const wchar_t *kPartLabel);
 	static bool MountFirstPartitionOnDrive(DWORD DriveIndex, CString &driveLetter);
 	static bool CreateCorrectPartitionLayout(HANDLE hPhysical, PBYTE layout, PBYTE geometry);
 

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -410,7 +410,8 @@ private:
 	static void ImageUnpackCallback(const uint64_t read_bytes);
 	static void UpdateUnpackProgress(const uint64_t current_bytes, const uint64_t total_bytes);
 	static bool CopyFilesToexFAT(CEndlessUsbToolDlg *dlg, const CString &fromFolder, const CString &driveLetter);
-	static bool WriteMBRAndSBRToUSB(HANDLE hPhysical, const CString &bootFilesPath, DWORD bytesPerSector);
+	static bool WriteMBRToUSB(HANDLE hPhysical, const CString &bootFilesPath);
+	static bool WriteBIOSBootPartitionToUSB(HANDLE hPhysical, const CString &bootFilesPath, DWORD bytesPerSector);
 
 	static DWORD WINAPI SetupDualBoot(LPVOID param);
 	static bool SetupDualBootFiles(CEndlessUsbToolDlg *dlg, const CString &systemDriveLetter, const CString &bootFilesPath, ErrorCause &errorCause);

--- a/src/endless/IOUtil.cpp
+++ b/src/endless/IOUtil.cpp
@@ -1,0 +1,56 @@
+#include "stdafx.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "GeneralCode.h"
+
+#define PERROR(_err, msg) do { \
+    if (_err != 0) { \
+        uprintf("%s:%d %s: %s",__FILE__, __LINE__, msg, strerror(_err)); \
+        goto error; \
+    } \
+} while (0)
+
+// Reads 'path', in its entirety, into 'buffer'.
+// Returns the number of bytes read, or 0 if the file is larger than
+// 'buffer_size' or an error occurred.
+size_t ReadEntireFile(const wchar_t *path, unsigned char *buffer, size_t buffer_size) {
+    FILE *fp = NULL;
+    long size = 0;
+    size_t size_read = 0;
+    errno_t err;
+
+    FUNCTION_ENTER_FMT("%ls", path);
+
+    err = _wfopen_s(&fp, path, L"rb");
+    PERROR(err, "_wfopen_s failed");
+
+    err = fseek(fp, 0L, SEEK_END);
+    PERROR(err, "fseek(SEEK_END) failed");
+
+    size = ftell(fp);
+    rewind(fp);
+
+    IFFALSE_GOTOERROR(size >= 0, "ftell returned negative");
+    if ((size_t) size > buffer_size) {
+        uprintf("%ls is %ld bytes long; supplied buffer is only %Id bytes", path, size, buffer_size);
+        goto error;
+    }
+    buffer_size = size;
+
+    while (!feof(fp) && !ferror(fp) && size_read < buffer_size) {
+        size_t count = fread(buffer + size_read, 1, 512, fp);
+        size_read += count;
+    }
+
+    err = ferror(fp);
+    if (err != 0) {
+        size_read = 0;
+        PERROR(err, "fread failed");
+    }
+
+error:
+    safe_closefile(fp);
+    return size_read;
+}

--- a/src/endless/IOUtil.h
+++ b/src/endless/IOUtil.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <stdlib.h>
+
+size_t ReadEntireFile(const wchar_t *path, unsigned char *buffer, size_t buffer_size);

--- a/src/format.c
+++ b/src/format.c
@@ -1440,50 +1440,6 @@ static BOOL SetupWinToGo(const char* drive_name, BOOL use_ms_efi)
 	return TRUE;
 }
 
-/*
- * Detect if a Windows Format prompt is active, by enumerating the
- * whole Windows tree and looking for the relevant popup
- */
-static BOOL CALLBACK FormatPromptCallback(HWND hWnd, LPARAM lParam)
-{
-	char str_buf[MAX_PATH];
-	HWND *hFound = (HWND*)lParam;
-	static const char* security_string = "Microsoft Windows";
-
-	// The format prompt has the popup window style
-	if (GetWindowLong(hWnd, GWL_STYLE) & WS_POPUPWINDOW) {
-		str_buf[0] = 0;
-		GetWindowTextA(hWnd, str_buf, MAX_PATH);
-		str_buf[MAX_PATH-1] = 0;
-		if (safe_strcmp(str_buf, security_string) == 0) {
-			*hFound = hWnd;
-			return TRUE;
-		}
-	}
-	return TRUE;
-}
-
-/*
- * When we format a drive that doesn't have any existing partitions, we can't lock it
- * prior to partitioning, which means that Windows will display a "You need to format the
- * disk in drive X: before you can use it'. You will also get that popup if you start a
- * bad blocks check and cancel it before it completes. We have to close that popup manually.
- */
-static DWORD WINAPI CloseFormatPromptThread(LPVOID param) {
-	HWND hFormatPrompt;
-
-	while(format_op_in_progress) {
-		hFormatPrompt = NULL;
-		EnumChildWindows(GetDesktopWindow(), FormatPromptCallback, (LPARAM)&hFormatPrompt);
-		if (hFormatPrompt != NULL) {
-			SendMessage(hFormatPrompt, WM_COMMAND, (WPARAM)IDCANCEL, (LPARAM)0);
-			uprintf("Closed Windows format prompt\n");
-		}
-		Sleep(100);
-	}
-	ExitThread(0);
-}
-
 static void update_progress(const uint64_t processed_bytes)
 {
 	if (_GetTickCount64() > LastRefresh + MAX_REFRESH) {
@@ -1728,7 +1684,6 @@ DWORD WINAPI FormatThread(void* param)
 		FormatStatus = ERROR_SEVERITY_ERROR|FAC(FACILITY_STORAGE)|ERROR_PARTITION_FAILURE;
 		goto out;
 	}
-	CreateThread(NULL, 0, CloseFormatPromptThread, NULL, 0, NULL);
 
 	if (zero_drive) {
 		WriteDrive(hPhysicalDrive, NULL);

--- a/src/format.c
+++ b/src/format.c
@@ -1502,6 +1502,7 @@ static BOOL WriteDrive(HANDLE hPhysicalDrive, HANDLE hSourceImage)
 	LARGE_INTEGER li;
 	DWORD rSize, wSize, BufSize;
 	uint64_t wb, target_size = hSourceImage?img_report.projected_size:SelectedDrive.DiskSize;
+	int64_t bled_ret;
 	uint8_t *buffer = NULL, *aligned_buffer;
 	int i;
 
@@ -1512,19 +1513,16 @@ static BOOL WriteDrive(HANDLE hPhysicalDrive, HANDLE hSourceImage)
 	LastRefresh = 0;
 
 	if (img_report.compression_type != BLED_COMPRESSION_NONE) {
-		uprintf("Writing Compressed Image...");
+		uprintf("Writing compressed image...");
 		bled_init(_uprintf, update_progress, &FormatStatus);
-#ifndef ENDLESSUSB_TOOL
-        bled_uncompress_with_handles(hSourceImage, hPhysicalDrive, img_report.compression_type);
-#else
-/// RADU: propose this change to rufus
-		if (-1 == bled_uncompress_with_handles(hSourceImage, hPhysicalDrive, img_report.compression_type)) {
-            if (SCODE_CODE(FormatStatus) != ERROR_CANCELLED) {
-                FormatStatus = ERROR_SEVERITY_ERROR | FAC(FACILITY_STORAGE) | ERROR_NO_MEDIA_IN_DRIVE;
-            }
-		}
-#endif // !ENDLESSUSB_TOOL
+		bled_ret = bled_uncompress_with_handles(hSourceImage, hPhysicalDrive, img_report.compression_type);
 		bled_exit();
+		if ((bled_ret < 0) && (SCODE_CODE(FormatStatus) != ERROR_CANCELLED)) {
+			// Unfortunately, different compression backends return different negative error codes
+			uprintf("Could not write compressed image: %" PRIi64, bled_ret);
+			FormatStatus = ERROR_SEVERITY_ERROR | FAC(FACILITY_STORAGE) | ERROR_WRITE_FAULT;
+			goto out;
+		}
 	} else {
 		uprintf(hSourceImage?"Writing Image...":"Zeroing drive...");
 		// Our buffer size must be a multiple of the sector size

--- a/src/format.c
+++ b/src/format.c
@@ -842,7 +842,7 @@ out:
 	return r;
 }
 
-static BOOL ClearMBRGPT(HANDLE hPhysicalDrive, LONGLONG DiskSize, DWORD SectorSize, BOOL add1MB)
+BOOL ClearMBRGPT(HANDLE hPhysicalDrive, LONGLONG DiskSize, DWORD SectorSize, BOOL add1MB)
 {
 	BOOL r = FALSE;
 	uint64_t i, last_sector = DiskSize/SectorSize;

--- a/src/format.c
+++ b/src/format.c
@@ -676,14 +676,13 @@ out:
 /*
  * Call on fmifs.dll's FormatEx() to format a partition. Returns FALSE with FormatStatus set on error.
  */
-BOOL FormatPartition(DWORD DriveIndex, wchar_t *wFSType, wchar_t *partLabel, ULONG ulClusterSize)
+BOOL FormatPartition(const char *VolumeName, wchar_t *wFSType, wchar_t *partLabel, ULONG ulClusterSize)
 {
 	BOOL r = FALSE;
 	PF_DECL(FormatEx);
-	char *locale, *VolumeName = NULL;
+	char *locale;
 	WCHAR* wVolumeName = NULL;
 
-	VolumeName = GetLogicalName(DriveIndex, FALSE, TRUE);
 	wVolumeName = utf8_to_wchar(VolumeName);
 	if (wVolumeName == NULL) {
 		uprintf("Could not read volume name\n");
@@ -707,7 +706,6 @@ BOOL FormatPartition(DWORD DriveIndex, wchar_t *wFSType, wchar_t *partLabel, ULO
 	}
 
 out:
-	safe_free(VolumeName);
 	safe_free(wVolumeName);
 	return r;
 }

--- a/src/msapi_utf8.h
+++ b/src/msapi_utf8.h
@@ -223,6 +223,21 @@ static __inline int MessageBoxExU(HWND hWnd, LPCSTR lpText, LPCSTR lpCaption, UI
 	return ret;
 }
 
+static __inline int LoadStringU(HINSTANCE hInstance, UINT uID, LPSTR lpBuffer, int nBufferMax)
+{
+	int ret;
+	DWORD err = ERROR_INVALID_DATA;
+	walloc(lpBuffer, nBufferMax);
+	ret = LoadStringW(hInstance, uID, wlpBuffer, nBufferMax);
+	err = GetLastError();
+	if ((ret > 0) && ((ret = wchar_to_utf8_no_alloc(wlpBuffer, lpBuffer, nBufferMax)) == 0)) {
+		err = GetLastError();
+	}
+	wfree(lpBuffer);
+	SetLastError(err);
+	return ret;
+}
+
 static __inline int DrawTextU(HDC hDC, LPCSTR lpText, int nCount, LPRECT lpRect, UINT uFormat)
 {
 	int ret;
@@ -861,6 +876,15 @@ static __inline int _mkdirU(const char* dirname)
 	ret = _wmkdir(wdirname);
 	wfree(dirname);
 	return ret;
+}
+
+static __inline HMODULE LoadLibraryU(LPCSTR lpFileName)
+{
+	HMODULE h;
+	wconvert(lpFileName);
+	h = LoadLibraryW(wlpFileName);
+	wfree(lpFileName);
+	return h;
 }
 
 #ifdef __cplusplus

--- a/src/rufus.c
+++ b/src/rufus.c
@@ -3056,6 +3056,10 @@ relaunch:
 		}
 	}
 
+	// Set the hook to automatically close Windows' "You need to format the disk in drive..." prompt
+	if (!SetFormatPromptHook())
+		uprintf("Warning:Could not set 'Format Disk' prompt auto-close");
+
 	ShowWindow(hDlg, SW_SHOWNORMAL);
 	UpdateWindow(hDlg);
 
@@ -3268,6 +3272,7 @@ out:
 	if ((!external_loc_file) && (loc_file[0] != 0))
 		DeleteFileU(loc_file);
 	DestroyAllTooltips();
+	ClrFormatPromptHook();
 	exit_localization();
 	safe_free(image_path);
 	safe_free(locale_name);

--- a/src/rufus.h
+++ b/src/rufus.h
@@ -452,6 +452,10 @@ extern BOOL SetThreadAffinity(DWORD_PTR* thread_affinity, size_t num_threads);
 #define printbits(x) _printbits(sizeof(x), &x, 0)
 #define printbitslz(x) _printbits(sizeof(x), &x, 1)
 extern char* _printbits(size_t const size, void const * const ptr, int leading_zeroes);
+extern BOOL IsCurrentProcessElevated(void);
+extern char* GetCurrentMUI(void);
+extern BOOL SetFormatPromptHook(void);
+extern void ClrFormatPromptHook(void);
 
 BOOL FormatPartition(const char *VolumeName, wchar_t *wFSType, wchar_t *partLabel, ULONG ulClusterSize);
 BOOL ClearMBRGPT(HANDLE hPhysicalDrive, LONGLONG DiskSize, DWORD SectorSize, BOOL add1MB);

--- a/src/rufus.h
+++ b/src/rufus.h
@@ -453,7 +453,7 @@ extern BOOL SetThreadAffinity(DWORD_PTR* thread_affinity, size_t num_threads);
 #define printbitslz(x) _printbits(sizeof(x), &x, 1)
 extern char* _printbits(size_t const size, void const * const ptr, int leading_zeroes);
 
-BOOL FormatPartition(DWORD DriveIndex, wchar_t *wFSType, wchar_t *partLabel, ULONG ulClusterSize);
+BOOL FormatPartition(const char *VolumeName, wchar_t *wFSType, wchar_t *partLabel, ULONG ulClusterSize);
 
 DWORD WINAPI FormatThread(void* param);
 DWORD WINAPI SaveImageThread(void* param);

--- a/src/rufus.h
+++ b/src/rufus.h
@@ -453,6 +453,8 @@ extern BOOL SetThreadAffinity(DWORD_PTR* thread_affinity, size_t num_threads);
 #define printbitslz(x) _printbits(sizeof(x), &x, 1)
 extern char* _printbits(size_t const size, void const * const ptr, int leading_zeroes);
 
+BOOL FormatPartition(DWORD DriveIndex, wchar_t *wFSType, wchar_t *partLabel, ULONG ulClusterSize);
+
 DWORD WINAPI FormatThread(void* param);
 DWORD WINAPI SaveImageThread(void* param);
 DWORD WINAPI SumThread(void* param);

--- a/src/rufus.h
+++ b/src/rufus.h
@@ -454,6 +454,7 @@ extern BOOL SetThreadAffinity(DWORD_PTR* thread_affinity, size_t num_threads);
 extern char* _printbits(size_t const size, void const * const ptr, int leading_zeroes);
 
 BOOL FormatPartition(const char *VolumeName, wchar_t *wFSType, wchar_t *partLabel, ULONG ulClusterSize);
+BOOL ClearMBRGPT(HANDLE hPhysicalDrive, LONGLONG DiskSize, DWORD SectorSize, BOOL add1MB);
 
 DWORD WINAPI FormatThread(void* param);
 DWORD WINAPI SaveImageThread(void* param);

--- a/src/stdlg.c
+++ b/src/stdlg.c
@@ -63,6 +63,8 @@ static BOOL notification_is_question;
 static const notification_info* notification_more_info;
 static BOOL settings_commcheck = FALSE;
 static WNDPROC update_original_proc = NULL;
+static HWINEVENTHOOK fp_weh = NULL;
+static char *fp_title_str = "Microsoft Windows", *fp_button_str = "Format disk";
 
 extern loc_cmd* selected_locale;
 
@@ -1728,3 +1730,85 @@ INT_PTR MyDialogBox(HINSTANCE hInstance, int Dialog_ID, HWND hWndParent, DLGPROC
 	return ret;
 }
 #endif // !ENDLESSUSB_TOOL
+
+/*
+ * The following function calls are used to automatically detect and close the native
+ * Windows format prompt "You must format the disk in drive X:". To do that, we use an
+ * event hook that gets triggered whenever a window is placed in the foreground.
+ * In that hook, we look for a dialog that has style WS_POPUPWINDOW and has the relevant
+ * title. However, because the title in itself is too generic (the expectation is that
+ * it will be "Microsoft Windows") we also enumerate all the child controls from that
+ * prompt, using another callback, until we find one that contains the text we expect
+ * for the "Format disk" button.
+ * Oh, and since all of these strings are localized, we must first pick them up from
+ * the relevant mui (something like "C:\Windows\System32\en-GB\shell32.dll.mui")
+ */
+static BOOL CALLBACK FormatPromptCallback(HWND hWnd, LPARAM lParam)
+{
+	char str[128];
+	BOOL *found = (BOOL*)lParam;
+
+	if (GetWindowTextU(hWnd, str, sizeof(str)) == 0)
+		return TRUE;
+	if (safe_strcmp(str, fp_button_str) == 0)
+		*found = TRUE;
+	return TRUE;
+}
+
+static void CALLBACK FormatPromptHook(HWINEVENTHOOK hWinEventHook, DWORD Event, HWND hWnd, LONG idObject, LONG idChild, DWORD dwEventThread, DWORD dwmsEventTime)
+{
+	char str[128];
+	BOOL found;
+
+	if (Event == EVENT_SYSTEM_FOREGROUND) {
+		if (GetWindowLong(hWnd, GWL_STYLE) & WS_POPUPWINDOW) {
+			str[0] = 0;
+			GetWindowTextU(hWnd, str, sizeof(str));
+			if (safe_strcmp(str, fp_title_str) == 0) {
+				found = FALSE;
+				EnumChildWindows(hWnd, FormatPromptCallback, (LPARAM)&found);
+				if (found) {
+					SendMessage(hWnd, WM_COMMAND, (WPARAM)IDCANCEL, (LPARAM)0);
+					uprintf("Closed Windows format prompt");
+				}
+			}
+		}
+	}
+}
+
+BOOL SetFormatPromptHook(void)
+{
+	HMODULE mui_lib;
+	char mui_path[MAX_PATH];
+	static char title_str[128], button_str[128];
+
+	if (fp_weh != NULL)
+		return TRUE;	// No need to set again if active
+
+						// Fetch the localized strings in the relevant
+	static_sprintf(mui_path, "%s\\%s\\shell32.dll.mui", system_dir, GetCurrentMUI());
+	mui_lib = LoadLibraryU(mui_path);
+	if (mui_lib != NULL) {
+		// 4097 = "You need to format the disk in drive %c: before you can use it." (dialog text)
+		// 4125 = "Microsoft Windows" (dialog title)
+		// 4126 = "Format disk" (button)
+		if (LoadStringU(mui_lib, 4125, title_str, sizeof(title_str)) > 0)
+			fp_title_str = title_str;
+		else
+			uprintf("Warning: Could not locate localized format prompt title string in '%s': %s", mui_path, WindowsErrorString());
+		if (LoadStringU(mui_lib, 4126, button_str, sizeof(button_str)) > 0)
+			fp_button_str = button_str;
+		else
+			uprintf("Warning: Could not locate localized format prompt button string in '%s': %s", mui_path, WindowsErrorString());
+		FreeLibrary(mui_lib);
+	}
+
+	fp_weh = SetWinEventHook(EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, NULL,
+		FormatPromptHook, 0, 0, WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
+	return (fp_weh != NULL);
+}
+
+void ClrFormatPromptHook(void) {
+	UnhookWinEvent(fp_weh);
+	fp_weh = NULL;
+}


### PR DESCRIPTION
This is partly improving our own logic, and partly copying existing logic from Rufus upstream's FormatThread. (It would be nice to add support for our images upstream but I think we should first switch to consuming ISOs.)

This branch is not totally reliable but it is much more likely to succeed (in my testing) than the old incarnation. One fly in the ointment is that re-writing a USB stick that we previously wrote with this process fails very reliably at the ClearMBRGPT() stage. Writing the first sector-ful of zeros works fine, but writing successive sectors fails with weird errors like "file not found" in the same way that writing the second-stage GRUB used to fail. I think this is because overwriting the MBR causes Windows to rescan the drive. What I do not understand is that Rufus upstream does exactly this, and it successfully overwrites drives with our layout almost all the time. The nice thing is that, if you retry, the process works reliably.

Still outstanding:

* [x] Drop the DO NOT MERGE patch :-)
* [x] Maybe put a retry loop around ClearMBRGPT?
  * I tried this and it actually made things worse. The process got further but then the volume manager (I think) got stuck and I had to reboot. I think the real problem might be that we are assuming there is only one `Volume{GUID}` -type path for the USB stick but due to Win 10 1703 mounting all partitions there are actually three. There's a TODO in the code but perfect is the enemy of released.
* [x] Add the dozen or so new error codes to the big switch which controls whether "Try Again" appears on the final page. I don't really like this design so I might look at doing something better.

https://phabricator.endlessm.com/T13969