### PR TITLE
Improve logging when UpdateDownloadProgressThread exits

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -4436,10 +4436,16 @@ DWORD WINAPI CEndlessUsbToolDlg::UpdateDownloadProgressThread(void* param)
             {
                 DownloadStatus_t downloadStatus;
                 bool result = dlg->m_downloadManager.GetDownloadProgress(currentJob, downloadStatus, jobName);
-                if (!result || downloadStatus.done || downloadStatus.error) {
-                    uprintf("CEndlessUsbToolDlg::UpdateDownloadProgressThread - Exiting");
+
+                IFFALSE_GOTO(result, "GetDownloadProgress failed", done);
+                if (downloadStatus.done || downloadStatus.error) {
+                    uprintf("GetDownloadProgress reported download %s", downloadStatus.done ? "done" : "error");
+                    /* Both of these cases are (supposed to be) handled and
+                     * reported elsewhere.
+                     */
                     goto done;
                 }
+
                 ::PostMessage(dlg->m_hWnd, WM_FILE_DOWNLOAD_STATUS, (WPARAM) new DownloadStatus_t(downloadStatus), 0);
                 break;
             }
@@ -4447,6 +4453,7 @@ DWORD WINAPI CEndlessUsbToolDlg::UpdateDownloadProgressThread(void* param)
     }
 
 done:
+    uprintf("%s exiting", __FUNCTION__);
     dlg->m_downloadUpdateThread = INVALID_HANDLE_VALUE;
     CoUninitialize();
     return 0;


### PR DESCRIPTION
We saw a log where this thread decided to exit at the point where the
download appeared to be complete, but DownloadManager never signalled
that the download was done; 5½ hours later the user gave up and pressed
Cancel:

    01:43:06 - Download [EndlessDownloadTypeDualBootFiles3.3.9es_GT] progress 14.1 GB of 14.1 GB (2 of 5 files)
    01:43:06 - Operation OP_DOWNLOADING_FILES(9) with progress 99
    01:43:08 - Download [EndlessDownloadTypeDualBootFiles3.3.9es_GT] progress 14.1 GB of 14.1 GB (2 of 5 files)
    01:43:08 - Operation OP_DOWNLOADING_FILES(9) with progress 99
    01:43:10 - CEndlessUsbToolDlg::UpdateDownloadProgressThread - Exiting
    07:03:34 - EndlessUsbToolDlg.cpp:1106 NULL element at requested index. (GLE=[0])
    07:03:34 - CEndlessUsbToolDlg::WindowProc called with 336[0x150] (0, -1); FAILURE 0
    07:03:34 - EndlessUsbToolDlg.cpp:1106 NULL element at requested index. (GLE=[0])
    07:03:34 - CEndlessUsbToolDlg::WindowProc called with 334[0x14E] (0, 0); FAILURE 0
    07:03:34 - EndlessUsbToolDlg.cpp:3435 CEndlessUsbToolDlg::OnSelectedUSBDiskChanged
    07:03:34 - EndlessUsbToolDlg.cpp:3443 Selected drive index is invalid. (GLE=[0])
    07:13:07 - EndlessUsbToolDlg.cpp:2058 CEndlessUsbToolDlg::IsButtonDisabled
    07:13:07 - EndlessUsbToolDlg.cpp:3704 CEndlessUsbToolDlg::OnInstallCancelClicked

(I don't know what the deal is with the USB disk changing.)
The "Exiting" message does not indicate *why* the thread decided to
exit. Reading the code for GetDownloadProgress() I believe we'd see
additional logging in the !result and downloadStatus.error paths, so I
think BITS thought the job was done. (But in that case, it's supposed to
call our DownloadManager::JobModification method to tell us.)

Later parts of the log suggest that something may have gone awry with
BITS:

    07:13:07 - DownloadManager.cpp:432 Error calling EnumJobs. (HRESULT: 0x800706b5 Interfaz desconocida.)

Not really sure what's going on, but we can at least log more explicitly
why UpdateDownloadProgressThread is exiting.

https://phabricator.endlessm.com/T20891