### PR TITLE
Add GetSelectedRemoteImage() helper

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -3262,6 +3262,10 @@ void CEndlessUsbToolDlg::StartInstallationProcess()
 				m_bootArchiveSize = localEntry->bootArchiveSize;
 				m_unpackedImageSig = localEntry->unpackedImgSigPath;
 			} else {
+				uprintf("Can't use local file. hasBootArchive: %s, hasBootArchiveSig: %s, hasUnpackedImgSig: %s",
+					localEntry->hasBootArchive ? "true" : "false",
+					localEntry->hasBootArchiveSig ? "true" : "false",
+					localEntry->hasUnpackedImgSig ? "true" : "false");
 				m_useLocalFile = false;
 			}
 		}

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -467,6 +467,7 @@ private:
 
 	bool PackedImageAlreadyExists(const CString &filePath, ULONGLONG expectedSize, ULONGLONG expectedUnpackedSize, bool isInstaller);
 
+	bool GetSelectedRemoteImage(RemoteImageEntry &r);
 	ULONGLONG GetActualDownloadSize(const RemoteImageEntry &r, bool fullSize = false);
 	bool RemoteMatchesUnpackedImg(const CString &remoteFilePath, CString *unpackedImgSig = NULL);
 	bool IsDualBootOrCombinedUsb();


### PR DESCRIPTION
As well as reducing duplicated code, in `StartInstallationProcess()` we did not check the result of `FindIndex()` before passing it to `GetAt()`. If the former returns `NULL`, the latter crashes. We saw this assertion failing in a debug build; we don't have a backtrace but it seems likely this is the cause. (It's a should-not-happen code path but there we go.)

The new helper always checks the returned `POSITION`, and we now handle this should-not-happen case in `StartInstallationProcess()` in a similar way to the local case above it.

I also added some logging to the should-not-happen case, which I think is happening and leading to the crash we're seeing.

https://phabricator.endlessm.com/T20744