### PR TITLE
WMI/BitLocker: if there is no Win32_EncryptableVolume, assume no BitLocker

### DIFF
--- a/src/endless/WMI.cpp
+++ b/src/endless/WMI.cpp
@@ -111,7 +111,12 @@ BOOL WMI::IsBitlockedDrive(const CString & drive)
 
         /* If we can't get the volume's properties, assume it is encrypted. */
         IFFAILED_RETURN_VALUE(hres, "Next() failed", TRUE);
-        IFFALSE_RETURN_VALUE(uReturned == 1, "Next() didn't return 1 row", TRUE);
+
+        /* Machines with no Win32_EncryptableVolume objects are hopefully not
+         * encrypted with BitLocker (Windows feature disabled / not installed?)
+         * https://phabricator.endlessm.com/T22290
+         */
+        IFTRUE_RETURN_VALUE(uReturned == 0, "No matching Win32_EncryptableVolume found", FALSE);
 
         _variant_t vtProp;
 


### PR DESCRIPTION
Apparent regression from T21417 - previously we searched for the property and
drive at the same time, and took absence to mean no BitLocker. It seems there
are systems without BitLocker which have no Win32_EncryptableVolume object for
the system drive, which seems to suggest the whole feature is disabled or
missing somehow. Return FALSE in this case as before.

https://phabricator.endlessm.com/T22290