### PR TITLE
Add analytics note to front page.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,9 @@ indent_style = space
 [src/endless/gpt/*]
 indent_style = space
 
+[src/endless/res/*]
+indent_style = space
+
 [src/endless/Analytics.*]
 indent_style = tab
 

--- a/po/po2loc
+++ b/po/po2loc
@@ -97,33 +97,6 @@ with open(LOC_FILE, 'r') as f:
             break
 
 
-class BadTranslation(Exception):
-    pass
-
-
-support_url_rx = re.compile(r'https://support.endlessm.com/hc/([^/]+)/articles/(\d+)(?:\s*)$')
-def check_support_url(lang, entry):
-    m_en = support_url_rx.match(entry.msgid)
-    m_tr = support_url_rx.match(entry.msgstr)
-
-    def bad(reason):
-        raise BadTranslation("{entry.msgctxt} is mistranslated into {lang}: "
-                             "{reason}\n{entry}".format(entry=entry, reason=reason, lang=lang))
-
-    if not m_en:
-        if m_tr:
-            bad("English is not a support URL, but translation is")
-    elif not m_tr:
-        bad("English is a support URL, but translation is not")
-    else:
-        en_lang, en_id = m_en.groups()
-        tr_lang, tr_id = m_tr.groups()
-        if en_id != tr_id:
-            bad("Translated FAQ has a different ID to the English one. "
-                "They should be identical, except for the language code "
-                "if a version exists in that language")
-
-
 # Re-write the file starting with the preamble
 # and then append with Endless translations
 problems = []
@@ -153,11 +126,6 @@ with open(LOC_FILE, 'w') as f:
             if not msgstr:
                 # Use the English string if no translation yet
                 msgstr = entry.msgid
-            else:
-                try:
-                    check_support_url(lang, entry)
-                except BadTranslation as e:
-                    problems.append(e)
             # Escape quotes and line feeds
             msgstr = msgstr.replace('"', '\\"')
             msgstr = msgstr.replace('\n', '\\n')

--- a/po/rufus.pot
+++ b/po/rufus.pot
@@ -216,6 +216,10 @@ msgctxt "AdvancedOptionsText"
 msgid "For advanced install options using an <b>Endless USB Stick</b>, <a id='AdvancedOptionsLink'>click here</a>."
 msgstr ""
 
+msgctxt "PrivacyPolicyText"
+msgid "We collect anonymous data to improve this installer for everybody. <a id='PrivacyPolicyLink'>Click here</a> for more information, and to learn how to opt out."
+msgstr ""
+
 msgctxt "SelectStorageNextButton"
 msgid "Next"
 msgstr ""

--- a/po/rufus.pot
+++ b/po/rufus.pot
@@ -383,11 +383,6 @@ msgid "https://support.endlessm.com/hc/en-us/articles/115003662326"
 msgstr ""
 
 #, c-format
-msgctxt "MSG_314"
-msgid "http://community.endlessm.com/"
-msgstr ""
-
-#, c-format
 msgctxt "MSG_315"
 msgid "%s/%s Download"
 msgstr ""

--- a/po/rufus.pot
+++ b/po/rufus.pot
@@ -375,11 +375,14 @@ msgctxt "MSG_311"
 msgid "Writing"
 msgstr ""
 
-#. If this FAQ is translated into your language, replace "en-us" with the right language code.
-#. Otherwise, use exactly the same URL.
+#. Locale ID for https://support.endlessm.com/ URLs, in lower-case. Check
+#. https://support.zendesk.com/hc/en-us/articles/203761906 to find the right
+#. one for this language. For example, Simplified Chinese should use "zh-cn".
+#. (For historical reasons, the Brazilian Portuguese translation should use
+#. "pt", not "pt-br".) If your language is not listed there, use "en-us".
 #, c-format
-msgctxt "MSG_312"
-msgid "https://support.endlessm.com/hc/en-us/articles/115003662326"
+msgctxt "MSG_317"
+msgid "en-us"
 msgstr ""
 
 #, c-format
@@ -461,13 +464,6 @@ msgstr ""
 #, c-format
 msgctxt "MSG_328"
 msgid "Try again"
-msgstr ""
-
-#. If this FAQ is translated into your language, replace "en-us" with the right language code.
-#. Otherwise, use exactly the same URL.
-#, c-format
-msgctxt "MSG_329"
-msgid "https://support.endlessm.com/hc/en-us/articles/210527103"
 msgstr ""
 
 #, c-format
@@ -644,11 +640,6 @@ msgstr ""
 #, c-format
 msgctxt "MSG_370"
 msgid "Oops, something went wrong setting up Endless OS."
-msgstr ""
-
-#, c-format
-msgctxt "MSG_371"
-msgid "https://support.endlessm.com/hc/en-us/articles/213585826"
 msgstr ""
 
 #, c-format

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -354,6 +354,17 @@ const wchar_t* mainWindowTitle = L"Endless Installer";
 
 #define COMMUNITY_URL "https://community.endlessos.com/"
 
+#define SUPPORT_URL_BASE             "https://support.endlessm.com/hc/"
+#define SUPPORT_URL_BASE_WITH_LOCALE "https://support.endlessm.com/hc/en-us"
+#define SUPPORT_URL_TAIL_OFFSET      (sizeof SUPPORT_URL_BASE_WITH_LOCALE - 1)
+/* We include the full literal URLs in the source tree, even though we only ever
+ * use the tails to build localized URLs, so the en-us links can be searched
+ * for and followed easily by developers.
+ */
+#define CONNECTED_SUPPORT_URL        "https://support.endlessm.com/hc/en-us/articles/115003662326"
+#define USBBOOT_HOWTO_SUPPORT_URL    "https://support.endlessm.com/hc/en-us/articles/210527103"
+#define USB_LEARN_MORE_SUPPORT_URL   "https://support.endlessm.com/hc/en-us/articles/213585826"
+
 #pragma region Uninstall_registry_stuff
 #define REGKEY_WIN_UNINSTALL	L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"
 #define REGKEY_ENDLESS_OS		ENDLESS_OS_NAME
@@ -2237,7 +2248,8 @@ HRESULT CEndlessUsbToolDlg::OnLinkClicked(IHTMLElement* pElement)
 
     CComBSTR id;
     HRESULT hr;
-    uint32_t msg_id = 0;
+    const char *support_url_en_us = NULL;
+    CStringA support_url;
     const char *url = NULL;
 
     IFFALSE_RETURN_VALUE(pElement != NULL, "OnLinkClicked: Error getting element id", S_OK);
@@ -2246,23 +2258,29 @@ HRESULT CEndlessUsbToolDlg::OnLinkClicked(IHTMLElement* pElement)
     IFFAILED_RETURN_VALUE(hr, "OnLinkClicked: Error getting element id", S_OK);
 
     if (id == _T(ELEMENT_CONNECTED_SUPPORT_LINK)) {
-        msg_id = MSG_312;
+        support_url_en_us = CONNECTED_SUPPORT_URL;
     } else if (id == _T(ELEMENT_ENDLESS_SUPPORT) || id == _T(ELEMENT_STORAGE_SUPPORT_LINK)) {
         url = COMMUNITY_URL;
     } else if (id == _T(ELEMENT_CONNECTED_LINK)) {
         WinExec("c:\\windows\\system32\\control.exe ncpa.cpl", SW_NORMAL);
     } else if (id == _T(ELEMENT_USBBOOT_HOWTO)) {
-        msg_id = MSG_329;
+        support_url_en_us = USBBOOT_HOWTO_SUPPORT_URL;
     } else if (id == _T(ELEMENT_USB_LEARN_MORE)) {
-        msg_id = MSG_371;
+        support_url_en_us = USB_LEARN_MORE_SUPPORT_URL;
     } else if (id == _T(ELEMENT_VERSION_LINK)) {
         url = RELEASE_VER_TAG_URL;
     } else {
         uprintf("Unknown link clicked %ls", id);
     }
 
-    if (msg_id != 0) {
-        url = lmprintf(msg_id);
+    if (support_url_en_us != NULL) {
+        const char *lang_code = lmprintf(MSG_317);
+
+        support_url = SUPPORT_URL_BASE;
+        support_url += lang_code;
+        support_url += (support_url_en_us + SUPPORT_URL_TAIL_OFFSET);
+
+        url = support_url.GetString();
     }
 
     if (url != NULL) {

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -352,6 +352,8 @@ const wchar_t* mainWindowTitle = L"Endless Installer";
 
 #define FORMAT_STATUS_CANCEL (ERROR_SEVERITY_ERROR | FAC(FACILITY_STORAGE) | ERROR_CANCELLED)
 
+#define COMMUNITY_URL "https://community.endlessos.com/"
+
 #pragma region Uninstall_registry_stuff
 #define REGKEY_WIN_UNINSTALL	L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"
 #define REGKEY_ENDLESS_OS		ENDLESS_OS_NAME
@@ -365,6 +367,7 @@ const wchar_t* mainWindowTitle = L"Endless Installer";
 #define REGKEY_NOMODIFY			L"NoModify"
 
 #define REGKEY_DISPLAYNAME_TEXT	ENDLESS_OS_NAME
+#define REGKEY_HELP_LINK_TEXT	_T(COMMUNITY_URL)
 #define REGKEY_PUBLISHER_TEXT	L"Endless Mobile, Inc."
 #pragma endregion Uninstall_registry_stuff
 
@@ -2235,7 +2238,7 @@ HRESULT CEndlessUsbToolDlg::OnLinkClicked(IHTMLElement* pElement)
     CComBSTR id;
     HRESULT hr;
     uint32_t msg_id = 0;
-    char *url = NULL;
+    const char *url = NULL;
 
     IFFALSE_RETURN_VALUE(pElement != NULL, "OnLinkClicked: Error getting element id", S_OK);
 
@@ -2245,7 +2248,7 @@ HRESULT CEndlessUsbToolDlg::OnLinkClicked(IHTMLElement* pElement)
     if (id == _T(ELEMENT_CONNECTED_SUPPORT_LINK)) {
         msg_id = MSG_312;
     } else if (id == _T(ELEMENT_ENDLESS_SUPPORT) || id == _T(ELEMENT_STORAGE_SUPPORT_LINK)) {
-        msg_id = MSG_314;
+        url = COMMUNITY_URL;
     } else if (id == _T(ELEMENT_CONNECTED_LINK)) {
         WinExec("c:\\windows\\system32\\control.exe ncpa.cpl", SW_NORMAL);
     } else if (id == _T(ELEMENT_USBBOOT_HOWTO)) {
@@ -5966,7 +5969,7 @@ BOOL CEndlessUsbToolDlg::AddUninstallRegistryKeys(const CStringW &uninstallExePa
 	IFFALSE_GOTOERROR(result == ERROR_SUCCESS, "Error on CRegKey::Create.");
 
 	IFFALSE_GOTOERROR(ERROR_SUCCESS == registryKey.SetStringValue(REGKEY_DISPLAYNAME, REGKEY_DISPLAYNAME_TEXT), "Error on REGKEY_DISPLAYNAME");
-	IFFALSE_GOTOERROR(ERROR_SUCCESS == registryKey.SetStringValue(REGKEY_HELP_LINK, UTF8ToBSTR(lmprintf(MSG_314))), "Error on REGKEY_HELP_LINK");
+	IFFALSE_GOTOERROR(ERROR_SUCCESS == registryKey.SetStringValue(REGKEY_HELP_LINK, REGKEY_HELP_LINK_TEXT), "Error on REGKEY_HELP_LINK");
 	IFFALSE_GOTOERROR(ERROR_SUCCESS == registryKey.SetStringValue(REGKEY_UNINSTALL_STRING, CComBSTR(uninstallExePath)), "Error on REGKEY_UNINSTALL_STRING");
 	IFFALSE_GOTOERROR(ERROR_SUCCESS == registryKey.SetStringValue(REGKEY_INSTALL_LOCATION, CComBSTR(installPath)), "Error on REGKEY_INSTALL_LOCATION");
 	IFFALSE_GOTOERROR(ERROR_SUCCESS == registryKey.SetStringValue(REGKEY_PUBLISHER, REGKEY_PUBLISHER_TEXT), "Error on REGKEY_PUBLISHER");

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -2248,10 +2248,10 @@ HRESULT CEndlessUsbToolDlg::OnLinkClicked(IHTMLElement* pElement)
         msg_id = MSG_314;
     } else if (id == _T(ELEMENT_CONNECTED_LINK)) {
         WinExec("c:\\windows\\system32\\control.exe ncpa.cpl", SW_NORMAL);
-	} else if (id == _T(ELEMENT_USBBOOT_HOWTO)) {
-		msg_id = MSG_329;
-	} else if (id == _T(ELEMENT_USB_LEARN_MORE)) {
-		msg_id = MSG_371;
+    } else if (id == _T(ELEMENT_USBBOOT_HOWTO)) {
+        msg_id = MSG_329;
+    } else if (id == _T(ELEMENT_USB_LEARN_MORE)) {
+        msg_id = MSG_371;
     } else if (id == _T(ELEMENT_VERSION_LINK)) {
         url = RELEASE_VER_TAG_URL;
     } else {
@@ -2263,11 +2263,10 @@ HRESULT CEndlessUsbToolDlg::OnLinkClicked(IHTMLElement* pElement)
     }
 
     if (url != NULL) {
-        // Radu: do we care about the errors?
         ShellExecuteA(NULL, "open", url, NULL, NULL, SW_SHOWNORMAL);
     }
 
-	return S_OK;
+    return S_OK;
 }
 
 HRESULT CEndlessUsbToolDlg::OnLanguageChanged(IHTMLElement* pElement)

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -205,6 +205,7 @@ DWORD usbDevicesCount;
 #define ELEMENT_ERROR_DELETE_CHECKBOX   "DeleteFilesCheckbox"
 #define ELEMENT_ERROR_DELETE_TEXT       "DeleteFilesText"
 
+#define ELEMENT_PRIVACY_POLICY_LINK     "PrivacyPolicyLink"
 #define ELEMENT_VERSION_LINK            "VersionLink"
 
 // Javascript methods
@@ -364,6 +365,7 @@ const wchar_t* mainWindowTitle = L"Endless Installer";
 #define CONNECTED_SUPPORT_URL        "https://support.endlessm.com/hc/en-us/articles/115003662326"
 #define USBBOOT_HOWTO_SUPPORT_URL    "https://support.endlessm.com/hc/en-us/articles/210527103"
 #define USB_LEARN_MORE_SUPPORT_URL   "https://support.endlessm.com/hc/en-us/articles/213585826"
+#define PRIVACY_POLICY_SUPPORT_URL   "https://support.endlessm.com/hc/en-us/articles/214475943"
 
 #pragma region Uninstall_registry_stuff
 #define REGKEY_WIN_UNINSTALL	L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"
@@ -488,6 +490,7 @@ BEGIN_DHTML_EVENT_MAP(CEndlessUsbToolDlg)
 	DHTML_EVENT_ONCLICK(_T(ELEMENT_DUALBOOT_CLOSE_BUTTON), OnCloseAppClicked)
 	DHTML_EVENT_ONCLICK(_T(ELEMENT_DUALBOOT_ADVANCED_LINK), OnAdvancedOptionsClicked)
 	DHTML_EVENT_ONCLICK(_T(ELEMENT_DUALBOOT_INSTALL_BUTTON), OnInstallDualBootClicked)
+    DHTML_EVENT_ONCLICK(_T(ELEMENT_PRIVACY_POLICY_LINK), OnLinkClicked)
     DHTML_EVENT_ONCLICK(_T(ELEMENT_VERSION_LINK), OnLinkClicked)
 
 	// Advanced Page Handlers
@@ -2267,6 +2270,8 @@ HRESULT CEndlessUsbToolDlg::OnLinkClicked(IHTMLElement* pElement)
         support_url_en_us = USBBOOT_HOWTO_SUPPORT_URL;
     } else if (id == _T(ELEMENT_USB_LEARN_MORE)) {
         support_url_en_us = USB_LEARN_MORE_SUPPORT_URL;
+    } else if (id == _T(ELEMENT_PRIVACY_POLICY_LINK)) {
+        support_url_en_us = PRIVACY_POLICY_SUPPORT_URL;
     } else if (id == _T(ELEMENT_VERSION_LINK)) {
         url = RELEASE_VER_TAG_URL;
     } else {

--- a/src/endless/Resource.h
+++ b/src/endless/Resource.h
@@ -96,6 +96,7 @@
 #define HTML_ELEM_SelectStorageNextButton	2059
 #define HTML_ELEM_SelectStoragePreviousButton 2060
 #define HTML_ELEM_SelectStoragePageTitle	2061
+#define HTML_ELEM_PrivacyPolicyText			2062
 
 #define HTML_ELEM_StorageAgreementText 2063
 #define HTML_ELEM_DualBootLanguageLabel 2064

--- a/src/endless/localization_data.h
+++ b/src/endless/localization_data.h
@@ -94,6 +94,7 @@ const loc_control_id control_id[] = {
 	LOC_CTRL_HTML(DualBootInstallButton),
 	LOC_CTRL_HTML(DualBootRecommendation),
 	LOC_CTRL_HTML(AdvancedOptionsText),
+	LOC_CTRL_HTML(PrivacyPolicyText),
 	LOC_CTRL_HTML(SelectStorageNextButton),
 	LOC_CTRL_HTML(SelectStoragePreviousButton),
 	LOC_CTRL_HTML(SelectStoragePageTitle),

--- a/src/endless/res/EndlessFonts.css
+++ b/src/endless/res/EndlessFonts.css
@@ -3,52 +3,52 @@ Theoretically eot files will work for all versions of IE from 6 to latest (Edge 
 If it doesn't make the binary too big it doesn't hurt to add the TTF files also in case MS decides to drop EOT support.
 We can of course take into consideration including woff files also.
 
-Unfortunatelly we need to define different names for the fonts based on font-weight because previous to IE9 IE doesn't know
+Unfortunately we need to define different names for the fonts based on font-weight because previous to IE9 IE doesn't know
 how to select the proper font based on element font-weight.
 */
 
 /* Fonts CSS */
 @font-face {
-	font-family: Lato;
-	src: 	url("res:/CUS/#120"); /* EOT file for IE6-8 */
-	src: 	url('res:/CUS/#120?#iefix') format('embedded-opentype'), /* apparently for IE9, haven't seen any issues but doesn't hurt to have it*/
-			url('res:/CUS/#110') format('truetype'); /* TTF file for normal browswers IE9+ */
-	font-weight: normal;
+    font-family: Lato;
+    src:     url("res:/CUS/#120"); /* EOT file for IE6-8 */
+    src:     url('res:/CUS/#120?#iefix') format('embedded-opentype'), /* apparently for IE9, haven't seen any issues but doesn't hurt to have it*/
+             url('res:/CUS/#110') format('truetype'); /* TTF file for normal browsers IE9+ */
+    font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
-	font-family: LatoMedium;
-	src: 	url("res:/CUS/#121"); /* EOT file for IE6-8 */
-	src: 	url('res:/CUS/#121?#iefix') format('embedded-opentype'), /* apparently for IE9, haven't seen any issues but doesn't hurt to have it*/
-			url('res:/CUS/#111') format('truetype'); /* TTF file for normal browswers IE9+ */
-	font-weight: 600;
+    font-family: LatoMedium;
+    src:     url("res:/CUS/#121"); /* EOT file for IE6-8 */
+    src:     url('res:/CUS/#121?#iefix') format('embedded-opentype'), /* apparently for IE9, haven't seen any issues but doesn't hurt to have it*/
+             url('res:/CUS/#111') format('truetype'); /* TTF file for normal browsers IE9+ */
+    font-weight: 600;
     font-style: normal;
 }
 
 @font-face {
-	font-family: LatoBold;
-	src: 	url("res:/CUS/#122"); /* EOT file for IE6-8 */
-	src: 	url('res:/CUS/#122?#iefix') format('embedded-opentype'), /* apparently for IE9, haven't seen any issues but doesn't hurt to have it*/
-			url('res:/CUS/#112') format('truetype'); /* TTF file for normal browswers IE9+ */
-	font-weight: bold;
+    font-family: LatoBold;
+    src:     url("res:/CUS/#122"); /* EOT file for IE6-8 */
+    src:     url('res:/CUS/#122?#iefix') format('embedded-opentype'), /* apparently for IE9, haven't seen any issues but doesn't hurt to have it*/
+             url('res:/CUS/#112') format('truetype'); /* TTF file for normal browsers IE9+ */
+    font-weight: bold;
     font-style: normal;
 }
 
 @font-face {
-	font-family: LatoBlack;
-	src: 	url("res:/CUS/#123"); /* EOT file for IE6-8 */
-	src: 	url('res:/CUS/#123?#iefix') format('embedded-opentype'), /* apparently for IE9, haven't seen any issues but doesn't hurt to have it*/
-			url('res:/CUS/#113') format('truetype'); /* TTF file for normal browswers IE9+ */
-	font-weight: 900;
+    font-family: LatoBlack;
+    src:     url("res:/CUS/#123"); /* EOT file for IE6-8 */
+    src:     url('res:/CUS/#123?#iefix') format('embedded-opentype'), /* apparently for IE9, haven't seen any issues but doesn't hurt to have it*/
+             url('res:/CUS/#113') format('truetype'); /* TTF file for normal browsers IE9+ */
+    font-weight: 900;
     font-style: normal;
 }
 
 @font-face {
-	font-family: LatoLight;
-	src: 	url("res:/CUS/#124"); /* EOT file for IE6-8 */
-	src: 	url('res:/CUS/#124?#iefix') format('embedded-opentype'), /* apparently for IE9, haven't seen any issues but doesn't hurt to have it*/
-			url('res:/CUS/#114') format('truetype'); /* TTF file for normal browswers IE9+ */
-	font-weight: 900;
+    font-family: LatoLight;
+    src:     url("res:/CUS/#124"); /* EOT file for IE6-8 */
+    src:     url('res:/CUS/#124?#iefix') format('embedded-opentype'), /* apparently for IE9, haven't seen any issues but doesn't hurt to have it*/
+             url('res:/CUS/#114') format('truetype'); /* TTF file for normal browsers IE9+ */
+    font-weight: 900;
     font-style: normal;
 }

--- a/src/endless/res/EndlessUsbTool.css
+++ b/src/endless/res/EndlessUsbTool.css
@@ -2,13 +2,13 @@
 
 * {
     padding: 0px;
-    margin: 0px;	
+    margin: 0px;
 }
 
 
 body {
-	font-family: Lato;
-	background: #363d41
+    font-family: Lato;
+    background: #363d41
 }
 
 body.ModeNormal .ModeCoding,
@@ -17,295 +17,295 @@ body.ModeCoding .ModeNormal {
 }
 
 b {
-	font-family: LatoBold;
+    font-family: LatoBold;
 }
 
 #MainContainer {
     width: 746px;
     height: 512px;
-	border: 1px solid #363d41;
-	border-radius: 8px 8px 0 0;
-	overflow: hidden;
+    border: 1px solid #363d41;
+    border-radius: 8px 8px 0 0;
+    overflow: hidden;
 }
 
 /* Normal button */
 .Button {
-	height: 31px;
-	text-align: center;
-	cursor: pointer;
-	border: 1px solid;
-	border-color: #a1a1a1;
-	border-radius: 3px;
-	overflow: hidden;
+    height: 31px;
+    text-align: center;
+    cursor: pointer;
+    border: 1px solid;
+    border-color: #a1a1a1;
+    border-radius: 3px;
+    overflow: hidden;
 }
 
 .Button div {
-	color: #2e3436;	
-	padding-top: 8px;
-	padding-bottom: 6px;
-	text-align: center;
-	width: 100%;
-	height: 17px; /* .Button.height - padding-top - padding-bottom */
-	background: #fafafa; /*older than IE6 */
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fafafa', endColorstr='#e0e0e0', GradientType=0); /* IE6-9 */
-	background-image: linear-gradient(to bottom, #fafafa, #ededed 40%, #e0e0e0); /* IE10+ */
-	
-	text-shadow: 0 1px rgba(255, 255, 255, 0.76923); /* IE10+ */
-	box-shadow: inset 0 1px white, 0 1px white; /* IE10+ */
-	transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); /* IE10+ */
-	
-	font-size: 13px;
-	font-family: LatoMedium;
-	letter-spacing: 0.5px;
+    color: #2e3436;
+    padding-top: 8px;
+    padding-bottom: 6px;
+    text-align: center;
+    width: 100%;
+    height: 17px; /* .Button.height - padding-top - padding-bottom */
+    background: #fafafa; /*older than IE6 */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fafafa', endColorstr='#e0e0e0', GradientType=0); /* IE6-9 */
+    background-image: linear-gradient(to bottom, #fafafa, #ededed 40%, #e0e0e0); /* IE10+ */
+
+    text-shadow: 0 1px rgba(255, 255, 255, 0.76923); /* IE10+ */
+    box-shadow: inset 0 1px white, 0 1px white; /* IE10+ */
+    transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); /* IE10+ */
+
+    font-size: 13px;
+    font-family: LatoMedium;
+    letter-spacing: 0.5px;
 }
 
 .Button div:not([maxIE8]) {
-	height: 100%;
+    height: 100%;
 }
 
 .Button div:hover {
-	color: #2e3436;
-	background: #444444; /*older than IE6 */
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='white', endColorstr='#ededed',GradientType=0 ); /* IE6-9 */
-	background-image: linear-gradient(to bottom, white, #f7f7f7 40%, #ededed); /* IE10+ */
+    color: #2e3436;
+    background: #444444; /*older than IE6 */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='white', endColorstr='#ededed',GradientType=0 ); /* IE6-9 */
+    background-image: linear-gradient(to bottom, white, #f7f7f7 40%, #ededed); /* IE10+ */
 }
 
-.Button div:active {    
-	color: #8a8a8a;
-	background: #d6d6d6; /*older than IE6 */
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr=#d6d6d6, endColorstr='#e0e0e0',GradientType=0 ); /* IE6-9 */
-	background-image: linear-gradient(to bottom, #d6d6d6, gainsboro 40%, #e0e0e0); /* IE10+ */	
-	
-	box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px white; /* IE10+ */
+.Button div:active {
+    color: #8a8a8a;
+    background: #d6d6d6; /*older than IE6 */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr=#d6d6d6, endColorstr='#e0e0e0',GradientType=0 ); /* IE6-9 */
+    background-image: linear-gradient(to bottom, #d6d6d6, gainsboro 40%, #e0e0e0); /* IE10+ */
+
+    box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px white; /* IE10+ */
     transition-duration: 50ms; /* IE10+ */
 }
 
 .ButtonClose {
-	background-image:url("res:/IMG/#208");
-	background-repeat: no-repeat;
-	background-position: center;
-	border: none;
-	width: 33px !important;
-	height: 33px !important;
+    background-image:url("res:/IMG/#208");
+    background-repeat: no-repeat;
+    background-position: center;
+    border: none;
+    width: 33px !important;
+    height: 33px !important;
 }
 
 .ButtonClose:hover {
-	border: 1px solid;
-	border-color: #a1a1a1;
-	border-radius: 3px;
-	width: 31px !important;
-	height: 31px !important;
+    border: 1px solid;
+    border-color: #a1a1a1;
+    border-radius: 3px;
+    width: 31px !important;
+    height: 31px !important;
 }
 
 .ButtonClose:active {
-	background-color: #d6d6d6;
+    background-color: #d6d6d6;
 }
 
 /* Blue button */
 .ButtonBlue {
-	width: 160px;
-	border-color: #1c5187;	
+    width: 160px;
+    border-color: #1c5187;
 }
 
 .ButtonBlue:not([maxIE8]) {
-	width: 150px;
+    width: 150px;
 }
 
 .ButtonBlue div {
-	color: white;
-	background: #5f9ddd; /*older than IE6 */
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#5f9ddd', endColorstr='#3583d5',GradientType=0 ); /* IE6-9 */	
-	background-image: linear-gradient(to bottom, #5f9ddd, #4a90d9 40%, #3583d5);  /* IE10+ */
-	
-	text-shadow: 0 -1px rgba(0, 0, 0, 0.54353); /* IE10+ */
-	box-shadow: inset 0 1px rgba(255, 255, 255, 0.5), 0 1px white; /* IE10+ */
-	
-	font-family: LatoBlack;
+    color: white;
+    background: #5f9ddd; /*older than IE6 */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#5f9ddd', endColorstr='#3583d5',GradientType=0 ); /* IE6-9 */
+    background-image: linear-gradient(to bottom, #5f9ddd, #4a90d9 40%, #3583d5);  /* IE10+ */
+
+    text-shadow: 0 -1px rgba(0, 0, 0, 0.54353); /* IE10+ */
+    box-shadow: inset 0 1px rgba(255, 255, 255, 0.5), 0 1px white; /* IE10+ */
+
+    font-family: LatoBlack;
 }
 
 .ButtonBlue div:hover {
-	color: white;
-	background: #85b4e5; /*older than IE6 */    
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#85b4e5', endColorstr='#4a90d9',GradientType=0 ); /* IE6-9 */
-	background-image: linear-gradient(to bottom, #85b4e5, #5b9add 40%, #4a90d9); /* IE10+ */
-	
-	text-shadow: 0 -1px rgba(0, 0, 0, 0.51153); /* IE10+ */
+    color: white;
+    background: #85b4e5; /*older than IE6 */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#85b4e5', endColorstr='#4a90d9',GradientType=0 ); /* IE6-9 */
+    background-image: linear-gradient(to bottom, #85b4e5, #5b9add 40%, #4a90d9); /* IE10+ */
+
+    text-shadow: 0 -1px rgba(0, 0, 0, 0.51153); /* IE10+ */
 }
 
 .ButtonBlue div:active {
-	color: white;
-	background: #2b79cb; /*older than IE6 */    
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#2b79cb', endColorstr='#3583d5',GradientType=0 ); /* IE6-9 */
-	background-image: linear-gradient(to bottom, #2b79cb, #2e7fd3 40%, #3583d5); /* IE10+ */
-	
-	text-shadow: 0 -1px rgba(0, 0, 0, 0.62353); /* IE10+ */
+    color: white;
+    background: #2b79cb; /*older than IE6 */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#2b79cb', endColorstr='#3583d5',GradientType=0 ); /* IE6-9 */
+    background-image: linear-gradient(to bottom, #2b79cb, #2e7fd3 40%, #3583d5); /* IE10+ */
+
+    text-shadow: 0 -1px rgba(0, 0, 0, 0.62353); /* IE10+ */
     box-shadow: inset 0 1px rgba(0, 0, 0, 0.07), inset 0 2px 1px -2px rgba(0, 0, 0, 0.6), 0 1px white; /* IE10+ */
 }
 
 /* Disabled button */
 .ButtonDisabled  {
-	border-color: #a8a8a8;
+    border-color: #a8a8a8;
     cursor: not-allowed;
 }
 
 .ButtonDisabled div,
 .ButtonDisabled div:hover {
-	color: #c7c7c7;
-	background: transparent; /*older than IE6 */
-	filter: none;
-	background-image: transparent;
+    color: #c7c7c7;
+    background: transparent; /*older than IE6 */
+    filter: none;
+    background-image: transparent;
 
-	text-shadow: none; /* IE10+ */
-	box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); /* IE10+ */
+    text-shadow: none; /* IE10+ */
+    box-shadow: inset 0 1px rgba(255, 255, 255, 0), 0 1px rgba(255, 255, 255, 0); /* IE10+ */
 }
 
 .FullWidthContent {
-	width: 100%;
-	clear:both;
+    width: 100%;
+    clear:both;
 }
 
 a {
-	color: #2a76c6; /* #3164a4 */ ;
-	cursor: pointer;
-	text-decoration: underline;
+    color: #2a76c6; /* #3164a4 */ ;
+    cursor: pointer;
+    text-decoration: underline;
 }
 
 a:hover {
-	color: #4a90d9;
+    color: #4a90d9;
 }
 
 a:active {
-	color: #2a76c6;
+    color: #2a76c6;
 }
 
 select {
-	border-radius: 5px;
-	border: 2px solid #b9bcb5;
-	background-color: #ffffff;
-	color: #00000;	
-	font-size: 14px;
-	cursor: pointer;
-	padding-left: 10px;
-	height: 33px;
+    border-radius: 5px;
+    border: 2px solid #b9bcb5;
+    background-color: #ffffff;
+    color: #00000;
+    font-size: 14px;
+    cursor: pointer;
+    padding-left: 10px;
+    height: 33px;
 }
 
 select:disabled {
-	border-width: 1px;
-	color: #b9bbbb;
-	background-color: transparent;
+    border-width: 1px;
+    color: #b9bbbb;
+    background-color: transparent;
 }
 
 .ContentTitle {
-	font-size: 16px;
-	margin-top: 40px;
-	color: #2e2e2e;
-	font-family: LatoBold;
-	min-height: 30px;
+    font-size: 16px;
+    margin-top: 40px;
+    color: #2e2e2e;
+    font-family: LatoBold;
+    min-height: 30px;
 }
 
 
 /* Wizard page */
 .WizardPage {
-	background-color: #e6e6e6;
-	color: #656565;
+    background-color: #e6e6e6;
+    color: #656565;
 }
 
 .hidden {
-	display: none;
+    display: none;
 }
 
 .PageHeader {
     border-bottom: 1px solid #a1a1a1;
-	border-radius: 8px 8px 0 0;
-	height: 34px;
-	cursor: default;
-	padding: 6px;
-	
-	font-size: medium;
-	
-	background: #f7f7f7; /*older than IE6 */
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f7f7f7', endColorstr='#ededed',GradientType=0 ); /* IE6-9 */
-	background-image: linear-gradient(to bottom, #f7f7f7, #ededed); /* IE10+ */
-	
-	box-shadow: inset 0 -1px #d9d9d9, inset 0 1px white; /* IE10+ */
+    border-radius: 8px 8px 0 0;
+    height: 34px;
+    cursor: default;
+    padding: 6px;
+
+    font-size: medium;
+
+    background: #f7f7f7; /*older than IE6 */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f7f7f7', endColorstr='#ededed',GradientType=0 ); /* IE6-9 */
+    background-image: linear-gradient(to bottom, #f7f7f7, #ededed); /* IE10+ */
+
+    box-shadow: inset 0 -1px #d9d9d9, inset 0 1px white; /* IE10+ */
 }
 
 .PageHeader .PageHeaderTitle {
     color: black;
-	text-align: center;
-	font-family: LatoBlack;    
-	font-size: 18px;
-	padding-top: 7px;
+    text-align: center;
+    font-family: LatoBlack;
+    font-size: 18px;
+    padding-top: 7px;
     padding-left: 12px;
     padding-right: 12px;
-	margin: 0px auto;	
-	letter-spacing: 0.5px;
-	max-width: 570px;
+    margin: 0px auto;
+    letter-spacing: 0.5px;
+    max-width: 570px;
 }
 
 .PageHeader .Button {
-	width: 80px;
-	float: left;
+    width: 80px;
+    float: left;
 }
 
 .PageHeader .ButtonRight {
-	float: right;	
+    float: right;
 }
 
-.PageContent {	
-	height: 415px;
-	border: 1px solid transparent;	
+.PageContent {
+    height: 415px;
+    border: 1px solid transparent;
 }
 
 /* Wizard Page indicator */
 .PageIndicator {
-	height: 50px;
-	text-align: center;
+    height: 50px;
+    text-align: center;
 }
 
 .PageIndicator ul {
-	display:inline-block;
-	margin-top: 10px;
-	/* hack for IE <=7 centering */
-	*display:inline;
-	*zoom:1;	
+    display:inline-block;
+    margin-top: 10px;
+    /* hack for IE <=7 centering */
+    *display:inline;
+    *zoom:1;
 }
 
 .PageIndicator ul li {
-	list-style: none;
-	float:left;	
+    list-style: none;
+    float:left;
 }
 
 .PageIndicator li span {
-	display:block;
-	width: 6px;
-	height: 6px;
-	margin: 2px;
-	background-image:url("res:/IMG/#200");
+    display:block;
+    width: 6px;
+    height: 6px;
+    margin: 2px;
+    background-image:url("res:/IMG/#200");
 }
 
 .PageIndicator li span.PageSelected {
-	background-image: url("res:/IMG/#201");
+    background-image: url("res:/IMG/#201");
 }
 
 .ContentContainer {
-	margin: 0px auto;
-	border-top: 1px solid #d0d0d0;
+    margin: 0px auto;
+    border-top: 1px solid #d0d0d0;
 }
 
 .PageSubtitle {
-	text-align: center;
-	height: 55px;
-	margin-top: 35px;
-	font-size: 17px;
+    text-align: center;
+    height: 55px;
+    margin-top: 35px;
+    font-size: 17px;
 }
 
 .RoundedCornersContainer {
-	width: 100%;
-	border: 1px solid #cecece;
-	border-radius: 10px;
-	background: #dbdbdb;
-	overflow: hidden;
+    width: 100%;
+    border: 1px solid #cecece;
+    border-radius: 10px;
+    background: #dbdbdb;
+    overflow: hidden;
 }
 
 .LanguageContainer {
@@ -319,18 +319,18 @@ select:disabled {
 
 #DualBootInstallPage .ContentContainer {
     height: 328px;
-	width: 670px;
-	border: 0;
+    width: 670px;
+    border: 0;
 }
 
 #DualBootInstallPage .RoundedCornersContainer {
     background: transparent; /*older than IE6 */
     height: 230px;
-	margin-top: 25px;
+    margin-top: 25px;
 }
 
 #DualBootInstallPage .PageContent .FullWidthContent {
-	padding-top: 10px;
+    padding-top: 10px;
     text-align: center;
 }
 
@@ -338,21 +338,21 @@ select:disabled {
 #DualBootInstallPage .RoundedCornersContainer {
     margin-top: 40px;
     font-size: 14px;
-	text-align: center;
+    text-align: center;
 }
 
 #DualBootContentLogo {
-	position: absolute;
-	padding: 0 15px;
-	top: 74px; /* trial and error to match up with the design */
-	left: 315px; /* (page width (746px) - logo width (85px) - padding (30px)) // 2 */
-	background: #e6e6e6; /* .WizardPage background; covers up some of the border */
+    position: absolute;
+    padding: 0 15px;
+    top: 74px; /* trial and error to match up with the design */
+    left: 315px; /* (page width (746px) - logo width (85px) - padding (30px)) // 2 */
+    background: #e6e6e6; /* .WizardPage background; covers up some of the border */
 }
 
 #DualBootContentLogoImage {
-	width: 85px;
-	height: 37px;
-	background: url("res:/IMG/#209") 0 0 no-repeat;
+    width: 85px;
+    height: 37px;
+    background: url("res:/IMG/#209") 0 0 no-repeat;
 }
 
 #DualBootContentTitle {
@@ -360,28 +360,28 @@ select:disabled {
     font-family: LatoBold;
     color: #000000;
     width: 100%;
-	margin: 0;
-	padding-top: 20px;
-	text-align: center;
+    margin: 0;
+    padding-top: 20px;
+    text-align: center;
 }
 
 #DualBootContentDescription {
     width: 70%;
-	margin: 0 15%;
+    margin: 0 15%;
     padding-top: 20px;
     letter-spacing: 0.5px;
-	text-align: center;
+    text-align: center;
 }
 
 #DualBootInstallButtonC {
-	margin: 20px auto;
+    margin: 20px auto;
 }
 
 #DualBootRecommendation {
     font-family: LatoBold;
     font-size: 11px;
     width: 85%;
-	margin: 0 7.5%;
+    margin: 0 7.5%;
     text-align: center;
 }
 
@@ -390,12 +390,11 @@ select:disabled {
     font-size: 14px;
 }
 
-
 /* Advanced page */
 
 #AdvancedPage .ContentContainer {
-	width: 670px;
-	border: 0;
+    width: 670px;
+    border: 0;
 }
 
 #AdvancedPage .RoundedCornersContainer {
@@ -408,8 +407,8 @@ select:disabled {
 }
 
 .ContentPanel {
-	float: left;
-	width: 320px;
+    float: left;
+    width: 320px;
     margin-top: 30px;
     padding-bottom: 25px;
 }
@@ -419,46 +418,46 @@ select:disabled {
 }
 
 .ContentPanel * {
-	margin: 0px auto;
+    margin: 0px auto;
 }
 
 .ContentPanel .Button {
-	margin-top: 25px;
+    margin-top: 25px;
 }
 
 .PanelImage {
-	width: 211px;
-	height: 113px;
-	background-repeat: no-repeat;
-	margin-top: 30px;
-	background-position: center; 
+    width: 211px;
+    height: 113px;
+    background-repeat: no-repeat;
+    margin-top: 30px;
+    background-position: center;
 }
 
 #LeftPaneImage {
-	background-image: url("res:/IMG/#202");
+    background-image: url("res:/IMG/#202");
 }
 
 #RightPaneImage {
-	background-image: url("res:/IMG/#203");
+    background-image: url("res:/IMG/#203");
 }
 
 .PanelText {
-	width: 80%;
-	font-size: 15px;
-	margin-top: 20px;
-	text-align: center;
-	height: 30px;
+    width: 80%;
+    font-size: 15px;
+    margin-top: 20px;
+    text-align: center;
+    height: 30px;
     font-family: LatoBold;
 }
 
 #AdvancedPage .PageContent .FullWidthContent {
-	/*height: 25px;*/
-	text-align: center;
-	padding-top: 15px;
+    /*height: 25px;*/
+    text-align: center;
+    padding-top: 15px;
 }
 
 .LanguageSelect {
-	width: 254px;	
+    width: 254px;
 }
 
 #AdvancedInstallReminder {
@@ -487,30 +486,30 @@ select:disabled {
 #SelectStoragePage .PageContent,
 #InstallingPage .PageContent,
 #ThankYouPage .PageContent  {
-	margin: 0px auto;
+    margin: 0px auto;
 }
 
 #SelectFilePage #SelectFileLocalNotPresent {
-	width: 670px;
+    width: 670px;
 }
 
 #SelectFilePage #SelectFileLocalPresent,
 #SelectStoragePage .ContentContainer,
 #SelectUSBPage .ContentContainer {
-	width: 515px;
-	padding-left: 20px;
+    width: 515px;
+    padding-left: 20px;
 }
-	
+
 #SelectStoragePage .ContentContainer,
 #SelectUSBPage .ContentContainer {
-	padding-left: 40px;
+    padding-left: 40px;
 }
 
 #SelectFilePage select,
 #SelectStoragePage select,
-#SelectUSBPage select, 
+#SelectUSBPage select,
 #NewDiskNameContainer  {
-	width: 460px;
+    width: 460px;
 }
 
 #NewDiskNameContainer {
@@ -518,152 +517,152 @@ select:disabled {
 }
 
 #SelectFilePage .ContentTitle {
-	margin-left: 20px;
+    margin-left: 20px;
 }
 
 #DownloadNewImage {
-	margin-top: 60px;
+    margin-top: 60px;
 }
 
-#SelectFilePage .Fieldset {	
-	width: 320px;
-	height: 254px;
-	border: 1px solid #cecece;
-	border-radius: 10px;
-	margin-top: 46px;
+#SelectFilePage .Fieldset {
+    width: 320px;
+    height: 254px;
+    border: 1px solid #cecece;
+    border-radius: 10px;
+    margin-top: 46px;
 }
 
 #SelectFilePage .Fieldset * {
-	margin: 0px auto;
-	text-align: center;
+    margin: 0px auto;
+    text-align: center;
 }
 
 #SelectFilePage .Fieldset:first-child {
-	float: left;
+    float: left;
 }
 
 #SelectFilePage .Fieldset:first-child  + .Fieldset{
-	float: right;
+    float: right;
 }
 
 #SelectFilePage .Fieldset .FieldsetTitle{
-	font-size: 26px;
-	font-family: LatoLight;
-	color: #000000;	
-	margin-top: -18px;
+    font-size: 26px;
+    font-family: LatoLight;
+    color: #000000;
+    margin-top: -18px;
     zoom: 1; /* Fix for IE7 clipping the top of the title */
 }
 
 #SelectFilePage .Fieldset .FieldsetTitle span {
-	background-color: #e6e6e6;
-	min-width: 235px;
-	padding: 0px 15px;
+    background-color: #e6e6e6;
+    min-width: 235px;
+    padding: 0px 15px;
 }
 
 #SelectFilePage .Fieldset .FieldsetTitle b {
-	font-family: LatoBold;
+    font-family: LatoBold;
 }
 
 /*#SelectFilePage .Fieldset .FieldsetTitle sup {
-	font-size: 16px;
-	font-family: LatoBold;
+    font-size: 16px;
+    font-family: LatoBold;
 }*/
 
 #SelectFilePage .Fieldset .FieldsetSubtitle {
-	margin-top: 9px;
-	font-family: LatoMedium;
-	font-size: 16px;
+    margin-top: 9px;
+    font-family: LatoMedium;
+    font-size: 16px;
 }
 
 #SelectFilePage .Fieldset .FieldsetDescription {
-	margin-top: 19px;
-	font-size: 13px;
-	max-width: 240px;
-	height: 145px;
-	text-align: justify;
+    margin-top: 19px;
+    font-size: 13px;
+    max-width: 240px;
+    height: 145px;
+    text-align: justify;
 }
 
 /* Selects the .Fieldset adjacent to the first .Fieldset in the page, which is
  * to say the right column.
  */
 #SelectFilePage .Fieldset:first-child  + .Fieldset .FieldsetDescription {
-	/*  145   description height (above)
-	 * - 33   select { height }
-	 * - 10   select { margin-top }
-	 * -  5   select { margin-bottom }
-	 */
-	height: 97px;
+    /*  145   description height (above)
+     * - 33   select { height }
+     * - 10   select { margin-top }
+     * -  5   select { margin-bottom }
+     */
+    height: 97px;
 }
 
 #SelectFilePage .Fieldset select {
-	margin-top: 10px;
-	margin-bottom: 5px;
-	width: 240px;
+    margin-top: 10px;
+    margin-bottom: 5px;
+    width: 240px;
 }
 
 #SelectFilePage .Fieldset .Button {
-	/* 2px narrower than <select> because it has a 1px border each side */
-	width: 238px;
+    /* 2px narrower than <select> because it has a 1px border each side */
+    width: 238px;
 }
 
 #NoInternetConnection {
-	text-align: center;
+    text-align: center;
 }
 
 #NoInternetConnectionTitle {
-	color: #000000;
-	font-family: LatoBold;
-	font-size: 16px;
+    color: #000000;
+    font-family: LatoBold;
+    font-size: 16px;
 }
 
 #NoInternetConnectionSubtitle {
-	font-size: 13px;
-	margin-top: 5px;
+    font-size: 13px;
+    margin-top: 5px;
 }
 
 #OfflineText {
-	font-family: LatoBold;
+    font-family: LatoBold;
 }
 
 #NewDiskNameContainer {
-	margin-top: 10px;
-	font-size: 13px;
+    margin-top: 10px;
+    font-size: 13px;
 }
-	
+
 #NewDiskNameContainer  div{
-	width: 46%;
-	float: left;
+    width: 46%;
+    float: left;
 }
 
 #NewDiskNameContainer label {
-	display: block;
-	font-family: LatoBold;
-	margin-bottom: 5px;
+    display: block;
+    font-family: LatoBold;
+    margin-bottom: 5px;
 }
 
 #NewDiskSizeLabel,
 #NewDiskSize{
-	float: right;
-	clear: both;
+    float: right;
+    clear: both;
 }
 
 .AgreementContainer b {
-	font-family: LatoBold;
+    font-family: LatoBold;
 }
 
 .AgreementContainer * {
-	color: black;
-	font-size: 13px;
-	font-family: LatoMedium;
+    color: black;
+    font-size: 13px;
+    font-family: LatoMedium;
 }
 
 #AgreementContainer div {
-	margin-top: 10px;
-	min-height: 70px;
-	text-align: center;
-	width: 460px;
-	color: red;
-	font-size: 12px;
+    margin-top: 10px;
+    min-height: 70px;
+    text-align: center;
+    width: 460px;
+    color: red;
+    font-size: 12px;
 }
 
 /* Select Storage Page */
@@ -671,7 +670,7 @@ select:disabled {
 #StorageFooter {
     padding-top: 10px;
     font-size: 13px;
-	font-family: Lato;
+    font-family: Lato;
     margin-top: 100px !important;
 }
 
@@ -680,10 +679,10 @@ select:disabled {
 }
 
 #SelectStoragePage .ContentTitle {
-	min-height: 70px;
-	/*text-align: center;*/
-	font-size: 13px;
-	font-family: Lato;
+    min-height: 70px;
+    /*text-align: center;*/
+    font-size: 13px;
+    font-family: Lato;
 }
 
 #SelectStorageAvailableSpace {
@@ -697,161 +696,161 @@ select:disabled {
 #InstallingPage .ContentContainer,
 #ThankYouPage .ContentContainer,
 #ErrorPage .ContentContainer {
-	border: 0;
-	width: 572px;
+    border: 0;
+    width: 572px;
 }
 
 #InstallingPage .ContentTitle {
-	width: 100%;
-	text-align: center;
-	font-size: 18px;
-	font-family: Lato;
-	margin-top: 44px;
+    width: 100%;
+    text-align: center;
+    font-size: 18px;
+    font-family: Lato;
+    margin-top: 44px;
 }
 
 #CurrentStepText {
-	font-family: LatoBold;
+    font-family: LatoBold;
 }
 
 #HideCornersContainer {
-	margin: 0px auto 16px;
-	width: 493px; /* ProgressBarContainer width+2*border */
-	height: 5px; /* ProgressBarContainer height+2*border */
-	overflow: hidden;
-	box-shadow: 0 1px white; /* IE10+ */	
+    margin: 0px auto 16px;
+    width: 493px; /* ProgressBarContainer width+2*border */
+    height: 5px; /* ProgressBarContainer height+2*border */
+    overflow: hidden;
+    box-shadow: 0 1px white; /* IE10+ */
 }
 
 #HideCornersContainer,
 #ProgressBarContainer,
 #ProgressBar {
-	border-radius: 4px;
+    border-radius: 4px;
 }
 
 #ProgressBarContainer,
 #ProgressBar {
-	height: 3px;
-	border: 1px solid;
+    height: 3px;
+    border: 1px solid;
 
 }
 
 #ProgressBarContainer {
-	width: 491px;
-	border-color: #a8a8a7;
-	background: #ced0cf; /*older than IE6 */
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ced0cf', endColorstr='#c4c5c5', GradientType=0); /* IE6-9 */
-	background-image: linear-gradient(to bottom, #ced0cf, #dcdedd 50%, #c4c5c5); /* IE10+ */
+    width: 491px;
+    border-color: #a8a8a7;
+    background: #ced0cf; /*older than IE6 */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ced0cf', endColorstr='#c4c5c5', GradientType=0); /* IE6-9 */
+    background-image: linear-gradient(to bottom, #ced0cf, #dcdedd 50%, #c4c5c5); /* IE10+ */
 }
 
 #ProgressBar {
-	width: 100px;
-	margin-left: -1px;
-	margin-top: -1px;
-	border-color:#366aa7;
-	height: 3px;
-	background: #769ecb; /*older than IE6 */
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#769ecb', endColorstr='#5486bd', GradientType=0); /* IE6-9 */
-	background-image: linear-gradient(to bottom, #769ecb, #7ba7d3 50%, #5486bd); /* IE10+ */
+    width: 100px;
+    margin-left: -1px;
+    margin-top: -1px;
+    border-color:#366aa7;
+    height: 3px;
+    background: #769ecb; /*older than IE6 */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#769ecb', endColorstr='#5486bd', GradientType=0); /* IE6-9 */
+    background-image: linear-gradient(to bottom, #769ecb, #7ba7d3 50%, #5486bd); /* IE10+ */
 }
 
 #InstallingPage .ContentContainer .FullWidthContent {
-	text-align: center;
-	font-size: 13px;
+    text-align: center;
+    font-size: 13px;
 }
 
 #MarketingContainer {
-	height: 251px;
-	margin-top: 35px;
+    height: 251px;
+    margin-top: 35px;
 }
 
 #MarketingImage {
-	background: url("res:/IMG/#205") 0 0 no-repeat;
-	width: 572px;
-	height: 251px;
+    background: url("res:/IMG/#205") 0 0 no-repeat;
+    width: 572px;
+    height: 251px;
 }
 
 /* Thank you Page */
 
 #InstallOkImage {
-	width: 91px;
-	height: 72px;
-	background-image: url("res:/IMG/#206");
-	margin: 40px auto 0px;
+    width: 91px;
+    height: 72px;
+    background-image: url("res:/IMG/#206");
+    margin: 40px auto 0px;
 }
 
 #ErrorMessage,
 #ThankYouMessage {
-	margin: 23px auto;
-	max-width: 310px;
-	text-align: center;
+    margin: 23px auto;
+    max-width: 310px;
+    text-align: center;
 }
 
 .ImageDataRow {
-	text-align: center;
-	margin: 0px auto;
-	font-size: 13px;
+    text-align: center;
+    margin: 0px auto;
+    font-size: 13px;
 }
 
 .ImageDataRow label {
 }
 
 #SecureBootReminder {
-	margin-top: 38px;	
-	height: 113px;
-	font-size: 13px;	
+    margin-top: 38px;
+    height: 113px;
+    font-size: 13px;
 
 }
 
 #ReminderTextContainer {
-	margin-left: 40px;
-	margin-right: 40px;
+    margin-left: 40px;
+    margin-right: 40px;
 }
 
 #ReminderTextContainer .ReminderTitle {
-	padding-top: 31px;
-	font-family: LatoBold;	
+    padding-top: 31px;
+    font-family: LatoBold;
 }
 
 /* Error Page */
 
 #ErrorImage {
-	width: 80px;
-	height: 75px;
-	background-image: url("res:/IMG/#207");
-	margin: 65px auto 0px;
+    width: 80px;
+    height: 75px;
+    background-image: url("res:/IMG/#207");
+    margin: 65px auto 0px;
 }
 
 #ErrorMessageSuggestion {
-	margin-bottom: 25px;
-	max-width: 275px;
+    margin-bottom: 25px;
+    max-width: 275px;
 }
 
 #ErrorPage .PageContent .Button {
-	margin: 35px auto 10px;
+    margin: 35px auto 10px;
 }
 #DeleteFilesContainer {
-	margin-bottom: 20px;
-	min-height: 20px !important;
+    margin-bottom: 20px;
+    min-height: 20px !important;
 }
 
 
 #VersionContainer {
-	position: absolute;
-	right: 5px;
-	bottom: 10px;
+    position: absolute;
+    right: 5px;
+    bottom: 10px;
 
-	font-size: 9px;
-	text-align: right;
+    font-size: 9px;
+    text-align: right;
 }
 
 #VersionContainer, #VersionContainer a {
-	color: #d6d6d6;
-	text-decoration: none;
+    color: #d6d6d6;
+    text-decoration: none;
 }
 
 #VersionContainer a {
-	padding: 5px;
+    padding: 5px;
 }
 
 #VersionContainer a:hover {
-	color: #5f9ddd;
+    color: #5f9ddd;
 }

--- a/src/endless/res/EndlessUsbTool.css
+++ b/src/endless/res/EndlessUsbTool.css
@@ -390,6 +390,11 @@ select:disabled {
     font-size: 14px;
 }
 
+#PrivacyPolicyText {
+    margin-top: 7px;
+    font-size: 11px;
+}
+
 /* Advanced page */
 
 #AdvancedPage .ContentContainer {

--- a/src/endless/res/EndlessUsbTool.htm
+++ b/src/endless/res/EndlessUsbTool.htm
@@ -1,15 +1,15 @@
-<html>
+﻿<html>
 <head>
 <title>Endles USB Creator</title>
 <meta http-equiv="X-UA-Compatible" content="IE=10" />
 <meta charset="utf-8" />
-    
+
 <link type="text/css" rel="stylesheet" href="res:/CUS/#105" />
 <link type="text/css" rel="stylesheet" href="res:/CUS/#104" />
 
 <script src="res:/CUS/#106" type=text/javascript></script>
 </head>
-        
+
 <body id="CEndlessUsbToolDlg">
     <div id="MainContainer">
         <div id="DualBootInstallPage" class="WizardPage">
@@ -57,7 +57,7 @@
         <div id="AdvancedPage" class="WizardPage hidden">
             <div class="PageHeader">
                 <div class="Button"><div id="AdvancedPagePreviousButton">Previous</div></div>
-				<div class="Button ButtonRight ButtonClose" id="AdvancedPageCloseButton"></div>
+                <div class="Button ButtonRight ButtonClose" id="AdvancedPageCloseButton"></div>
                 <div id="AdvancedPageTitle" class="PageHeaderTitle">Advanced Install Options</div>
             </div>
 
@@ -66,19 +66,19 @@
                     <div id="AdvancedOptionsSubtitle">With an <b>Endless USB Stick</b> you can:</div>
                 </div>
 
-				<div class="ContentContainer">
-					<div class="ContentPanel RoundedCornersContainer" id="LeftPanel">
+                <div class="ContentContainer">
+                    <div class="ContentPanel RoundedCornersContainer" id="LeftPanel">
                         <div class="PanelText ModeNormal" id="LiveUsbText">Try Endless OS by running it from a USB stick.</div>
                         <div class="PanelText ModeCoding" id="LiveUsbTextCoding">Try Endless Code by running it from a USB stick.</div>
-						<div class="PanelImage" id="LeftPaneImage"> </div>
-						<div class="Button ButtonBlue hidden" id="LiveUsbButtonC"><div id="LiveUsbButton">Create Live USB</div></div>
-					</div>
-					<div class="ContentPanel RoundedCornersContainer" id="RightPanel" >
+                        <div class="PanelImage" id="LeftPaneImage"> </div>
+                        <div class="Button ButtonBlue hidden" id="LiveUsbButtonC"><div id="LiveUsbButton">Create Live USB</div></div>
+                    </div>
+                    <div class="ContentPanel RoundedCornersContainer" id="RightPanel" >
                         <div class="PanelText ModeNormal" id="ReformatterUsbText">Reformat any computer with Endless OS using a USB stick.</div>
                         <div class="PanelText ModeCoding" id="ReformatterUsbTextCoding">Reformat any computer with Endless Code using a USB stick.</div>
-						<div class="PanelImage" id="RightPaneImage"></div>
-						<div class="Button ButtonBlue hidden" id="ReformatterUsbButtonC"><div id="ReformatterUsbButton">Create Reformatter USB</div></div>
-					</div>
+                        <div class="PanelImage" id="RightPaneImage"></div>
+                        <div class="Button ButtonBlue hidden" id="ReformatterUsbButtonC"><div id="ReformatterUsbButton">Create Reformatter USB</div></div>
+                    </div>
                     <div class="FullWidthContent" id="AdvancedInstallReminder">
                         To create an Endless USB Stick you will need a USB device with at least 8 GB of storage space.
                     </div>
@@ -111,52 +111,52 @@
 
             <div class="PageContent">
                 <div class="FullWidthContent PageSubtitle">
-					<div id="SelectFileSubtitle">Select the Endless OS version you'd like to install.</div>
-					<div id="NoInternetConnection" class="hidden">
-						<div id="NoInternetConnectionTitle">Unfortunately, there was a problem connecting to the server.</div>
-						<div id="NoInternetConnectionSubtitle">Make sure you're <a id='ConnectedLink'>connected to the internet</a>, and if the problem persists, visit our <a id='ConnectedSupportLink'>support</a>.</div>
-					</div>
-				</div>
-				<div class="ContentContainer hidden" id="SelectFileLocalPresent">
+                    <div id="SelectFileSubtitle">Select the Endless OS version you'd like to install.</div>
+                    <div id="NoInternetConnection" class="hidden">
+                        <div id="NoInternetConnectionTitle">Unfortunately, there was a problem connecting to the server.</div>
+                        <div id="NoInternetConnectionSubtitle">Make sure you're <a id='ConnectedLink'>connected to the internet</a>, and if the problem persists, visit our <a id='ConnectedSupportLink'>support</a>.</div>
+                    </div>
+                </div>
+                <div class="ContentContainer hidden" id="SelectFileLocalPresent">
                     <div class="ContentTitle" id="ExistingImageFile">Operating system found:</div>
                     <input style="clear:both" type="radio" name="OperatingSystemType" id="OperatingSystemTypeLocal" checked="true" />
                     <select id="LocalImagesSelect" onclick="selectImageClicked('OperatingSystemTypeLocal');">
-                    </select> 
-                    
+                    </select>
+
                     <div class="ContentTitle" id="DownloadNewImage">Download new file:</div>
                     <input type="radio" name="OperatingSystemType" id="OperatingSystemTypeOnline" disabled="disabled"/>
                     <select id="OnlineImagesSelect" onclick="selectImageClicked('OperatingSystemTypeOnline');" disabled="disabled">
                     </select>
                 </div>
-				
-				<div class="ContentContainer" id="SelectFileLocalNotPresent">
-					<div class="Fieldset">
-						<div class="FieldsetTitle ModeNormal"><span>Endless OS <b id="LightVersionText">BASIC</b></span></div>
-						<div class="FieldsetTitle ModeCoding"><span>Endless Code <b id="LightVersionText">BASIC</b></span></div>
-						<div class="FieldsetSubtitle" id="LightDownloadSubtitle">…</div>
-						<div class="FieldsetDescription ModeNormal" id="LightDownloadDescription">Includes basic features of Endless OS and the option to download more apps and content later. This version is best for computers with reliable internet access.</div>
-						<div class="FieldsetDescription ModeCoding" id="LightDownloadDescriptionCoding">Includes basic features of Endless Code and the option to download more apps and content later. This version is best for computers with reliable internet access.</div>
-						<div id="DownloadLightButtonC" class="Button ButtonBlue ButtonDisabled">
+
+                <div class="ContentContainer" id="SelectFileLocalNotPresent">
+                    <div class="Fieldset">
+                        <div class="FieldsetTitle ModeNormal"><span>Endless OS <b id="LightVersionText">BASIC</b></span></div>
+                        <div class="FieldsetTitle ModeCoding"><span>Endless Code <b id="LightVersionText">BASIC</b></span></div>
+                        <div class="FieldsetSubtitle" id="LightDownloadSubtitle">…</div>
+                        <div class="FieldsetDescription ModeNormal" id="LightDownloadDescription">Includes basic features of Endless OS and the option to download more apps and content later. This version is best for computers with reliable internet access.</div>
+                        <div class="FieldsetDescription ModeCoding" id="LightDownloadDescriptionCoding">Includes basic features of Endless Code and the option to download more apps and content later. This version is best for computers with reliable internet access.</div>
+                        <div id="DownloadLightButtonC" class="Button ButtonBlue ButtonDisabled">
                             <div id="DownloadLightButton">Download Basic</div>
                         </div>
-					</div>
-					
-					<div class="Fieldset">
-						<div class="FieldsetTitle ModeNormal"><span>Endless OS <b id="FullVersionText">Full</b></span></div>
-						<div class="FieldsetTitle ModeCoding"><span>Endless Code <b id="FullVersionText">Full</b></span></div>
-						<div class="FieldsetSubtitle" id="FullDownloadSubtitle">…</div>
-						<div class="FieldsetDescription ModeNormal" id="FullDownloadDescription">Includes full Endless OS, preloaded with more than 100 apps and content. This version is ideal for computers without reliable internet access. Choose language for content and apps:</div>
-						<div class="FieldsetDescription ModeCoding" id="FullDownloadDescriptionCoding">Includes full Endless Code, preloaded with more than 100 apps and content. This version is ideal for computers without reliable internet access. Choose language for content and apps:</div>
-						<div class="FullWidthContent">
-							<select id="DownloadLanguageSelect" disabled="disabled" onchange="remoteSelectionChanged();">
-								<!-- These will be added at runtime -->
-							</select> 
-						</div>
-						<div id="DownloadFullButtonC" class="Button ButtonBlue ButtonDisabled">
+                    </div>
+
+                    <div class="Fieldset">
+                        <div class="FieldsetTitle ModeNormal"><span>Endless OS <b id="FullVersionText">Full</b></span></div>
+                        <div class="FieldsetTitle ModeCoding"><span>Endless Code <b id="FullVersionText">Full</b></span></div>
+                        <div class="FieldsetSubtitle" id="FullDownloadSubtitle">…</div>
+                        <div class="FieldsetDescription ModeNormal" id="FullDownloadDescription">Includes full Endless OS, preloaded with more than 100 apps and content. This version is ideal for computers without reliable internet access. Choose language for content and apps:</div>
+                        <div class="FieldsetDescription ModeCoding" id="FullDownloadDescriptionCoding">Includes full Endless Code, preloaded with more than 100 apps and content. This version is ideal for computers without reliable internet access. Choose language for content and apps:</div>
+                        <div class="FullWidthContent">
+                            <select id="DownloadLanguageSelect" disabled="disabled" onchange="remoteSelectionChanged();">
+                                <!-- These will be added at runtime -->
+                            </select>
+                        </div>
+                        <div id="DownloadFullButtonC" class="Button ButtonBlue ButtonDisabled">
                             <div id="DownloadFullButton">Download Full</div>
                         </div>
-					</div>
-				</div>				
+                    </div>
+                </div>
             </div>
 
             <div class="FullWidthContent PageIndicator">
@@ -168,7 +168,7 @@
                 </ul>
             </div>
         </div>
-		
+
         <div id="SelectUSBPage" class="WizardPage hidden">
             <div class="PageHeader">
                 <div class="Button"><div id="SelectUSBPreviousButton">Previous</div></div>
@@ -178,29 +178,29 @@
 
             <div class="PageContent">
                 <div class="FullWidthContent PageSubtitle" id="SelectUSBSubtitle">Choose the USB device you would like to use.</div>
-				<div class="ContentContainer">
+                <div class="ContentContainer">
                     <div class="ContentTitle" id="USBDisksFound">USB drive found:</div>
                     <select id="USBDiskSelect" disabled="disabled">
                         <!-- These will be added at runtime -->
                     </select>
                     <div id="NewDiskNameContainer">
-						<div>
-							<label for="NewDiskName" id="NewDiskNameLabel">USB's new name will appear as:</label>
-							<span id="NewDiskName">EOS 2_7 English Light</span>
-						</div>
-						<div>						
-							<label for="NewDiskSize" id="NewDiskSizeLabel">Size:</label>
-							<span id="NewDiskSize">2GB</span>
-						</div>                    
-					</div>
-                </div>				
-				<div class="ContentContainer AgreementContainer" id="AgreementContainer">
-					<div id="UsbSpeedWarning">
-						You have a USB 3.0 device but it is inserted into a USB 2.0 port. Please insert it into a USB 3.0 port (usually blue) for the best experience.
-					</div>
+                        <div>
+                            <label for="NewDiskName" id="NewDiskNameLabel">USB's new name will appear as:</label>
+                            <span id="NewDiskName">EOS 2_7 English Light</span>
+                        </div>
+                        <div>
+                            <label for="NewDiskSize" id="NewDiskSizeLabel">Size:</label>
+                            <span id="NewDiskSize">2GB</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="ContentContainer AgreementContainer" id="AgreementContainer">
+                    <div id="UsbSpeedWarning">
+                        You have a USB 3.0 device but it is inserted into a USB 2.0 port. Please insert it into a USB 3.0 port (usually blue) for the best experience.
+                    </div>
                     <input type="checkbox" id="AgreementCheckbox" />
                     <label for="AgreementCheckbox" id="AgreementCheckboxText">I understand that this will <b>erase all my files</b> on the USB device.</label>
-                </div>				
+                </div>
             </div>
 
             <div class="PageIndicator">
@@ -236,11 +236,11 @@
                     </select>
                 </div>
                 <div class="ContentContainer AgreementContainer" id="StorageFooter">
-					<div id="StorageSpaceWarning" class="hidden">
-						The selected version of Endless OS requires X GB of free disk space, but only Y GB is available. Please free up some space on drive Z:\ to continue.
-					</div>
+                    <div id="StorageSpaceWarning" class="hidden">
+                        The selected version of Endless OS requires X GB of free disk space, but only Y GB is available. Please free up some space on drive Z:\ to continue.
+                    </div>
                     <div id="StorageAgreementText">
-						Note: We recommend backing up any important files before continuing. Should you experience any problems with your computer after installation, you can find help at <a id="StorageSupportLink">Endless Support</a>.
+                        Note: We recommend backing up any important files before continuing. Should you experience any problems with your computer after installation, you can find help at <a id="StorageSupportLink">Endless Support</a>.
                     </div>
                 </div>
             </div>
@@ -257,29 +257,29 @@
 
         <div id="InstallingPage" class="WizardPage hidden">
             <div class="PageHeader">
-				<div id="InstallCancelButtonC" class="Button ButtonRight"><div id="InstallCancelButton">Cancel</div></div>
+                <div id="InstallCancelButtonC" class="Button ButtonRight"><div id="InstallCancelButton">Cancel</div></div>
                 <div class="ModeNormal"><div class="PageHeaderTitle" id="InstallingPageTitle">Installing</div></div>
                 <div class="ModeCoding"><div class="PageHeaderTitle" id="InstallingPageTitleCoding">Installing</div></div>
             </div>
 
             <div class="PageContent">
-				<div class="ContentContainer">
-					<div class="ContentTitle">
-						<span id="CurrentStepText">Step 1</span> <span id="TotalStepsText">of 5:</span> <span id="CurrentStepDescription">: Downloading</span>
-					</div>
-					<div id="HideCornersContainer">
-						<div class="ProgressBarContainer" id="ProgressBarContainer">
-							<div id="ProgressBar"></div>
-						</div>
-					</div>
-					<div class="FullWidthContent">
-						&nbsp;<span id="InstallStepStatus">512Mb of 2.12 Gb (500k / sec)</span>&nbsp;
-					</div>
-					
-					<div id="MarketingContainer" class="RoundedCornersContainer">
-						<div id="MarketingImage"></div>											
-					</div>
-				</div>
+                <div class="ContentContainer">
+                    <div class="ContentTitle">
+                        <span id="CurrentStepText">Step 1</span> <span id="TotalStepsText">of 5:</span> <span id="CurrentStepDescription">: Downloading</span>
+                    </div>
+                    <div id="HideCornersContainer">
+                        <div class="ProgressBarContainer" id="ProgressBarContainer">
+                            <div id="ProgressBar"></div>
+                        </div>
+                    </div>
+                    <div class="FullWidthContent">
+                        &nbsp;<span id="InstallStepStatus">512Mb of 2.12 Gb (500k / sec)</span>&nbsp;
+                    </div>
+
+                    <div id="MarketingContainer" class="RoundedCornersContainer">
+                        <div id="MarketingImage"></div>
+                    </div>
+                </div>
             </div>
 
             <div class="PageIndicator">
@@ -294,38 +294,38 @@
 
         <div id="ThankYouPage" class="WizardPage hidden">
             <div class="PageHeader">
-				<div class="Button ButtonBlue ButtonRight"><div id="CloseAppButton">Close</div></div>
+                <div class="Button ButtonBlue ButtonRight"><div id="CloseAppButton">Close</div></div>
                 <div id="ThankYouPageTitle" class="PageHeaderTitle">Thank you</div>
             </div>
 
             <div class="PageContent">
-				<div class="ContentContainer">
-					<div id="InstallOkImage"></div>
-					<div class="ContentTitle" id="ThankYouMessage">Great! Your EOS2_7 English Light Installer device is sucessfully created.</div>
-					<div class="ImageDataRow">
-						<label for="InstallerVersionValue" id="InstallerVersion">Version:</label>
-						<span id="InstallerVersionValue">---</span>
-					</div>
-					<div id="InstallerLanguageRow" class="ImageDataRow">
-						<label for="InstallerLanguageValue" id="InstallerLanguage">Language:</label>
-						<span id="InstallerLanguageValue">---</span>
-					</div>
-					<div class="ImageDataRow">
-						<label for="InstallerContentValue" id="InstallerContent">Content:</label>
-						<span id="InstallerContentValue">---</span>
-					</div>
-                
-					<div id="SecureBootReminder" class="RoundedCornersContainer">
-						<div id="ReminderTextContainer">
+                <div class="ContentContainer">
+                    <div id="InstallOkImage"></div>
+                    <div class="ContentTitle" id="ThankYouMessage">Great! Your EOS2_7 English Light Installer device is sucessfully created.</div>
+                    <div class="ImageDataRow">
+                        <label for="InstallerVersionValue" id="InstallerVersion">Version:</label>
+                        <span id="InstallerVersionValue">---</span>
+                    </div>
+                    <div id="InstallerLanguageRow" class="ImageDataRow">
+                        <label for="InstallerLanguageValue" id="InstallerLanguage">Language:</label>
+                        <span id="InstallerLanguageValue">---</span>
+                    </div>
+                    <div class="ImageDataRow">
+                        <label for="InstallerContentValue" id="InstallerContent">Content:</label>
+                        <span id="InstallerContentValue">---</span>
+                    </div>
+
+                    <div id="SecureBootReminder" class="RoundedCornersContainer">
+                        <div id="ReminderTextContainer">
                             <div class="ReminderTitle" id="ThankYouDualBootReminder">Restart your computer and select "Endless OS" from the menu.</div>
                             <div class="ReminderTitle ModeNormal" id="ThankYouLiveReminder">To try Endless OS now, restart your computer.</div>
                             <div class="ReminderTitle ModeCoding" id="ThankYouLiveReminderCoding">To try Endless Code now, restart your computer.</div>
                             <div class="ReminderTitle ModeNormal" id="ThankYouReflasherReminder">Now you're ready to install Endless OS on more computers.</div>
                             <div class="ReminderTitle ModeCoding" id="ThankYouReflasherReminderCoding">Now you're ready to install Endless Code on more computers.</div>
-							<a id="UsbBootHowToLink">How should I do it?</a>
-						</div>
-					</div>
-				</div>
+                            <a id="UsbBootHowToLink">How should I do it?</a>
+                        </div>
+                    </div>
+                </div>
             </div>
 
             <div class="PageIndicator">
@@ -344,21 +344,21 @@
             </div>
 
             <div class="PageContent">
-				<div class="ContentContainer">
-					<div id="ErrorImage"></div>
-					<div class="ContentTitle ModeNormal" id="ErrorMessage">Oops, something went wrong setting up Endless OS.</div>
-					<div class="ContentTitle ModeCoding" id="ErrorMessageCoding">Oops, something went wrong setting up Endless Code.</div>
-					<div class="ImageDataRow" id="ErrorMessageSuggestion">Please try again or contact us so we can help you troubleshoot.</div>
-					<div class="Button ButtonBlue hidden" id="ErrorContinueButtonC"><div id="ErrorContinueButton">Continue</div></div>
-					<div class="ImageDataRow " id="DeleteFilesContainer">
-						<input type="checkbox" id="DeleteFilesCheckbox"/>
-						<label for="DeleteFilesCheckbox" id="DeleteFilesText">Delete the invalid files (XX GB)</label>
-					</div>
-					<div class="ImageDataRow" id="EndlessSupportContainer">If you keep having trouble, you can get help on the <a id="EndlessSupport">Endless community forum</a>.</div>
-				</div>
+                <div class="ContentContainer">
+                    <div id="ErrorImage"></div>
+                    <div class="ContentTitle ModeNormal" id="ErrorMessage">Oops, something went wrong setting up Endless OS.</div>
+                    <div class="ContentTitle ModeCoding" id="ErrorMessageCoding">Oops, something went wrong setting up Endless Code.</div>
+                    <div class="ImageDataRow" id="ErrorMessageSuggestion">Please try again or contact us so we can help you troubleshoot.</div>
+                    <div class="Button ButtonBlue hidden" id="ErrorContinueButtonC"><div id="ErrorContinueButton">Continue</div></div>
+                    <div class="ImageDataRow " id="DeleteFilesContainer">
+                        <input type="checkbox" id="DeleteFilesCheckbox"/>
+                        <label for="DeleteFilesCheckbox" id="DeleteFilesText">Delete the invalid files (XX GB)</label>
+                    </div>
+                    <div class="ImageDataRow" id="EndlessSupportContainer">If you keep having trouble, you can get help on the <a id="EndlessSupport">Endless community forum</a>.</div>
+                </div>
             </div>
-			
-			<div class="PageIndicator">
+
+            <div class="PageIndicator">
                 <ul>
                     <li><span></span></li>
                     <li><span></span></li>

--- a/src/endless/res/EndlessUsbTool.htm
+++ b/src/endless/res/EndlessUsbTool.htm
@@ -32,6 +32,10 @@
                     <div class="FullWidthContent" id="AdvancedOptionsText">
                         For advanced install options using an <b>Endless USB Stick</b>, <a id='AdvancedOptionsLink'>click here</a>.
                     </div>
+
+                    <div class="FullWidthContent" id="PrivacyPolicyText">
+                        We collect anonymous data to improve this installer for everybody. <a id='PrivacyPolicyLink'>Click here</a> for more information, and to learn how to opt out.
+                    </div>
                 </div>
                 <div class="FullWidthContent LanguageContainer">
                     <select id="LanguageSelectDualBoot" class="LanguageSelect">

--- a/src/endless/res/EndlessUsbTool.js
+++ b/src/endless/res/EndlessUsbTool.js
@@ -16,36 +16,36 @@ function setProgress(percent) {
         currentPercent = percent;
         var bar = document.getElementById("ProgressBar");
         progressWidth = containerWidth * percent;
-//        clog("Setting " + progressWidth);
+        // clog("Setting " + progressWidth);
         bar.style.width = Math.ceil(progressWidth) + "px";
     }
 }
 
 function enableButton(id, enable) {
-	addClassName(id, enable, "ButtonDisabled");
+    addClassName(id, enable, "ButtonDisabled");
 }
 
 function enableElement(id, enable) {
-	var element = document.getElementById(id);
-	if(element == null) {
-		clog("F(enableElement) No element found with id " + id);
-	} else{
-		element.disabled = !enable;
-	}
+    var element = document.getElementById(id);
+    if (element == null) {
+        clog("F(enableElement) No element found with id " + id);
+    } else {
+        element.disabled = !enable;
+    }
 }
 
 function enableDownload(enable, internetConnected) {
     enableElement("OperatingSystemTypeOnline", internetConnected && enable);
     enableElement("OnlineImagesSelect", internetConnected && enable);
 
-	showElement("SelectFileSubtitle", internetConnected);
-	showElement("NoInternetConnection", !internetConnected);
+    showElement("SelectFileSubtitle", internetConnected);
+    showElement("NoInternetConnection", !internetConnected);
 
-	enableElement("DownloadLanguageSelect", internetConnected && enable);
-//	enableButton("DownloadLightButtonC", internetConnected && enable); //disabled by C++
-	enableButton("DownloadFullButtonC", internetConnected && enable);
+    enableElement("DownloadLanguageSelect", internetConnected && enable);
+    // enableButton("DownloadLightButtonC", internetConnected && enable); //disabled by C++
+    enableButton("DownloadFullButtonC", internetConnected && enable);
 
-	// enableButton("SelectFileNextButtonC", enable);
+    // enableButton("SelectFileNextButtonC", enable);
 }
 
 function addClassName(id, remove, classname) {
@@ -55,63 +55,63 @@ function addClassName(id, remove, classname) {
         return;
     }
 
-    if (remove) {		
+    if (remove) {
         elem.className = elem.className.replace(classname, "");
-    } else if (elem.className.indexOf(classname) == -1) {	
+    } else if (elem.className.indexOf(classname) == -1) {
         elem.className += " " + classname;
     }
 }
 
 function showElement(id, show) {
     var classname = "hidden";
-	addClassName(id, show, classname);    
+    addClassName(id, show, classname);
 }
 
 function triggerEvent(elem, eventName) {
-	if(document.fireEvent) {	
-		elem.fireEvent("on" + eventName);
-	} else {
-		var event;
-		if(document.createEvent) {
-			event = document.createEvent("HTMLEvents");
-			event.initEvent(eventName, true, true);
-		} else if(document.createEventObject){ // IE < 9
-			event = document.createEventObject();
+    if (document.fireEvent) {
+        elem.fireEvent("on" + eventName);
+    } else {
+        var event;
+        if (document.createEvent) {
+            event = document.createEvent("HTMLEvents");
+            event.initEvent(eventName, true, true);
+        } else if (document.createEventObject) { // IE < 9
+            event = document.createEventObject();
             event.eventType = eventName;
-		}
-		event.eventName = eventName;
-		clog(elem.dispatchEvent(event));
-	}
+        }
+        event.eventName = eventName;
+        clog(elem.dispatchEvent(event));
+    }
 }
-	
-function remoteSelectionChanged() {	
-	var element = document.getElementById("DownloadLanguageSelect");
-	clog("remoteSelectionChanged to " +  element.value);
-	var remoteSelect = document.getElementById("OnlineImagesSelect");
-	remoteSelect.selectedIndex = element.value;
-	triggerEvent(remoteSelect, "change"); // for c++
+
+function remoteSelectionChanged() {
+    var element = document.getElementById("DownloadLanguageSelect");
+    clog("remoteSelectionChanged to " + element.value);
+    var remoteSelect = document.getElementById("OnlineImagesSelect");
+    remoteSelect.selectedIndex = element.value;
+    triggerEvent(remoteSelect, "change"); // for c++
 }
 
 function selectImageClicked(inputId) {
-	var elem = document.getElementById(inputId);
-	if(elem == null) {
-		clog("Element is null " + inputId);
-		return;
-	}
-	elem.checked = true;
-	triggerEvent(elem, "change"); // for c++
+    var elem = document.getElementById(inputId);
+    if (elem == null) {
+        clog("Element is null " + inputId);
+        return;
+    }
+    elem.checked = true;
+    triggerEvent(elem, "change"); // for c++
 }
 
 function resetCheck(elemId) {
-	var elem = document.getElementById(elemId);
-	if(elem == null) {
-		clog("Element is null " + elemId);
-		return;
-	}
-	elem.checked = false;
+    var elem = document.getElementById(elemId);
+    if (elem == null) {
+        clog("Element is null " + elemId);
+        return;
+    }
+    elem.checked = false;
 }
 
 function setCodingMode(isCoding) {
-	var cls = isCoding ? "ModeCoding" : "ModeNormal";
-	addClassName("CEndlessUsbToolDlg", false, cls);
+    var cls = isCoding ? "ModeCoding" : "ModeNormal";
+    addClassName("CEndlessUsbToolDlg", false, cls);
 }

--- a/src/endless/res/endless.loc
+++ b/src/endless/res/endless.loc
@@ -239,7 +239,6 @@ t MSG_311 "Writing"
 # If this FAQ is translated into your language, replace "en-us" with the right language code.
 # Otherwise, use exactly the same URL.
 t MSG_312 "https://support.endlessm.com/hc/en-us/articles/115003662326"
-t MSG_314 "http://community.endlessm.com/"
 
 t MSG_315 "%s/%s Download"
 t MSG_316 "Full"

--- a/src/endless/res/endless.loc
+++ b/src/endless/res/endless.loc
@@ -236,9 +236,12 @@ t MSG_309 "Installing"
 t MSG_310 "Verifying"
 t MSG_311 "Writing"
 
-# If this FAQ is translated into your language, replace "en-us" with the right language code.
-# Otherwise, use exactly the same URL.
-t MSG_312 "https://support.endlessm.com/hc/en-us/articles/115003662326"
+# Locale ID for https://support.endlessm.com/ URLs, in lower-case. Check
+# https://support.zendesk.com/hc/en-us/articles/203761906 to find the right
+# one for this language. For example, Simplified Chinese should use "zh-cn".
+# (For historical reasons, the Brazilian Portuguese translation should use
+# "pt", not "pt-br".) If your language is not listed there, use "en-us".
+t MSG_317 "en-us"
 
 t MSG_315 "%s/%s Download"
 t MSG_316 "Full"
@@ -271,10 +274,6 @@ t MSG_326 "Resume"
 t MSG_327 "Download again"
 # This should match the string in quotes in MSG_325
 t MSG_328 "Try again"
-
-# If this FAQ is translated into your language, replace "en-us" with the right language code.
-# Otherwise, use exactly the same URL.
-t MSG_329 "https://support.endlessm.com/hc/en-us/articles/210527103"
 
 t MSG_330 "You have selected a slow USB device (USB 1.0). Please use a USB 3.0 device for the best experience."
 t MSG_331 "You have selected a slow USB device (USB 1.0). Please use a USB 2.0 device for a better experience."
@@ -338,7 +337,6 @@ t MSG_368 "Internet Explorer %d is not supported. Please click OK to download In
 t MSG_369 "%s Download"
 t MSG_370 "Oops, something went wrong setting up Endless OS."
 t MSG_381 "Oops, something went wrong setting up Endless Code."
-t MSG_371 "https://support.endlessm.com/hc/en-us/articles/213585826"
 t MSG_372 "No USB device found. If you've inserted one, try a different USB port or a different USB device."
 t MSG_386 "The Endless Installer requires Windows 7 or newer."
 

--- a/src/endless/res/endless.loc
+++ b/src/endless/res/endless.loc
@@ -161,6 +161,7 @@ t DualBootContentDescription "Each time you start your computer, you will be abl
 t DualBootInstallButton "Install Endless"
 t DualBootRecommendation "Recommended: At least 32 GB of free space on the system drive."
 t AdvancedOptionsText "For advanced install options using an <b>Endless USB Stick</b>, <a id='AdvancedOptionsLink'>click here</a>."
+t PrivacyPolicyText "We collect anonymous data to improve this installer for everybody. <a id='PrivacyPolicyLink'>Click here</a> for more information, and to learn how to opt out."
 t SelectStorageNextButton "Next"
 t SelectStoragePreviousButton "Previous"
 t SelectStoragePageTitle "Storage Space for Endless OS"


### PR DESCRIPTION
This is a superset of #127, and introduces string changes.

Here's what the note looks like:

![screenshot from 2018-05-25 15-04-03](https://user-images.githubusercontent.com/86760/40548532-e6738950-602c-11e8-8ad2-298011344fc1.png)

I finally made a change I've been putting off for ages. Previously, we marked each FAQ URL for translation. But the translation in each case is completely mechanical: if we have Zendesk translations in the current language, replace "en-us" with that language; if not, leave it as "en-us". Not only is this wasted work whenever we add a new URL, there have been cases where translators have modified other parts of the URL rather than just the language code (in response to which I added a check to po2loc), leading to incorrect articles being displayed.

So now, we just mark the Zendesk locale ID for translation. This does require an all-or-nothing approach to translating support articles, but I think it's the right change.

I also reformatted all the HTML, CSS and JavaScript code to consistently use 4-space indents.

https://phabricator.endlessm.com/T22737