### PR TITLE
WMI: call GetConversionStatus

### DIFF
--- a/src/endless/WMI.cpp
+++ b/src/endless/WMI.cpp
@@ -25,6 +25,35 @@ public:
     }
 };
 
+class WmiObject {
+public:
+    WmiObject(IWbemServices *pSvc, IWbemClassObject *pClass, IWbemClassObject *pInstance) :
+        m_pSvc(pSvc),
+        m_pClass(pClass),
+        m_pInstance(pInstance)
+    {
+    }
+
+    HRESULT ExecMethod(
+        LPCWSTR wszMethodName,
+        IWbemClassObject **ppOutParams = NULL,
+        LPCWSTR wszParam1Name = NULL, const CComVariant &cvParam1 = CComVariant(),
+        LPCWSTR wszParam2Name = NULL, const CComVariant &cvParam2 = CComVariant(),
+        LPCWSTR wszParam3Name = NULL, const CComVariant &cvParam3 = CComVariant(),
+        LPCWSTR wszParam4Name = NULL, const CComVariant &cvParam4 = CComVariant());
+
+protected:
+    static HRESULT EnumerateProperties(IWbemClassObject *pObject);
+    static HRESULT Get(IWbemClassObject *pObject, LPCWSTR wszName, VARIANT *vParam);
+    static HRESULT Put(IWbemClassObject *pObject, LPCWSTR wszName, const VARIANT &cvParam);
+
+    CComPtr<IWbemServices> m_pSvc;
+    // Methods are looked up on this
+    CComPtr<IWbemClassObject> m_pClass;
+    // Methods are called on this -- may equal m_pClass
+    CComPtr<IWbemClassObject> m_pInstance;
+};
+
 static HRESULT GetWMIProxy(const CString &objectPath, CComPtr<IWbemServices> &pSvc)
 {
     FUNCTION_ENTER;
@@ -221,35 +250,6 @@ typedef enum BcdBootMgrElementTypes {
 // Inspired by https://github.com/sysprogs/BazisLib/blob/master/bzshlp/Win32/BCD.cpp and
 // https://social.msdn.microsoft.com/Forums/sqlserver/en-US/a9996e4a-d2d7-4c42-87d2-48096ea47eb5/wmi-bcdobjects-using-c?forum=windowsgeneraldevelopmentissues#cb08edd9-297b-453d-a7ca-6c96574aee3f
 // -- thanks, both.
-class WmiObject {
-public:
-    WmiObject(IWbemServices *pSvc, IWbemClassObject *pClass, IWbemClassObject *pInstance) :
-        m_pSvc(pSvc),
-        m_pClass(pClass),
-        m_pInstance(pInstance)
-    {
-    }
-
-    HRESULT ExecMethod(
-        LPCWSTR wszMethodName,
-        IWbemClassObject **ppOutParams = NULL,
-        LPCWSTR wszParam1Name = NULL, const CComVariant &cvParam1 = CComVariant(),
-        LPCWSTR wszParam2Name = NULL, const CComVariant &cvParam2 = CComVariant(),
-        LPCWSTR wszParam3Name = NULL, const CComVariant &cvParam3 = CComVariant(),
-        LPCWSTR wszParam4Name = NULL, const CComVariant &cvParam4 = CComVariant());
-
-protected:
-    static HRESULT EnumerateProperties(IWbemClassObject *pObject);
-    static HRESULT Get(IWbemClassObject *pObject, LPCWSTR wszName, VARIANT *vParam);
-    static HRESULT Put(IWbemClassObject *pObject, LPCWSTR wszName, const VARIANT &cvParam);
-
-    CComPtr<IWbemServices> m_pSvc;
-    // Methods are looked up on this
-    CComPtr<IWbemClassObject> m_pClass;
-    // Methods are called on this -- may equal m_pClass
-    CComPtr<IWbemClassObject> m_pInstance;
-};
-
 class BcdBootmgr : public WmiObject {
 public:
     BcdBootmgr() : WmiObject(NULL, NULL, NULL) {}

--- a/src/endless/WMI.cpp
+++ b/src/endless/WMI.cpp
@@ -392,7 +392,6 @@ HRESULT WmiObject::ExecMethod(
 
     // Get the parameter specification
     CComPtr<IWbemClassObject> pInParamsDefinition;
-    WBEM_E_TYPE_MISMATCH;
     hres = m_pClass->GetMethod(wszMethodName, 0, &pInParamsDefinition, NULL);
     IFFAILED_RETURN_RES(hres, "GetMethod failed");
 


### PR DESCRIPTION
The ConversionStatus property is not [documented][0] to exist on Win32_EncryptableVolume. In my testing, it does exist on Windows 10, but [forum reports][1] indicate that it does not exist on Windows 7. As a result, we always entered the fail-safe path of assuming the disk is encrypted, and Endless OS could not be installed.

Instead, call [GetConversionStatus][2] and get ConversionStatus from the object it returns. ProtectionStatus is [documented][0] to exist, and the very helpful forum report agrees, so we continue to access that as we were before.

[0]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa376483(v=vs.85).aspx
[1]: https://community.endlessos.com/t/problem-with-installation-drive-encrypted/6300/5
[2]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa376433(v=vs.85).aspx

https://phabricator.endlessm.com/T22663