### PR TITLE
Don't unnecessarily lock (and open for write) physical volumes

### DIFF
--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -5690,7 +5690,7 @@ HANDLE CEndlessUsbToolDlg::GetPhysicalFromDriveLetter(const CString &driveLetter
 	safe_closehandle(hPhysical);
 
 	FormatStatus = 0;
-	hPhysical = GetPhysicalHandle(drive_number, writeAccess, TRUE);
+	hPhysical = GetPhysicalHandle(drive_number, writeAccess, FALSE);
 	IFFALSE_GOTOERROR(hPhysical != INVALID_HANDLE_VALUE, "Error on acquiring disk handle.");
 
 error:

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -5654,7 +5654,7 @@ bool CEndlessUsbToolDlg::SetupEndlessEFI(const CString &systemDriveLetter, const
 	CString windowsEspDriveLetter;
 	const char *espMountLetter = NULL;
 
-	hPhysical = GetPhysicalFromDriveLetter(systemDriveLetter);
+	hPhysical = GetPhysicalFromDriveLetter(systemDriveLetter, false);
 	IFFALSE_GOTOERROR(hPhysical != INVALID_HANDLE_VALUE, "Error on acquiring disk handle.");
 
 	IFFALSE_GOTOERROR(MountESPFromDrive(hPhysical, &espMountLetter, systemDriveLetter), "Error on MountESPFromDrive");
@@ -5674,7 +5674,7 @@ error:
 	return retResult;
 }
 
-HANDLE CEndlessUsbToolDlg::GetPhysicalFromDriveLetter(const CString &driveLetter)
+HANDLE CEndlessUsbToolDlg::GetPhysicalFromDriveLetter(const CString &driveLetter, bool writeAccess)
 {
 	FUNCTION_ENTER;
 
@@ -5690,7 +5690,7 @@ HANDLE CEndlessUsbToolDlg::GetPhysicalFromDriveLetter(const CString &driveLetter
 	safe_closehandle(hPhysical);
 
 	FormatStatus = 0;
-	hPhysical = GetPhysicalHandle(drive_number, TRUE, TRUE);
+	hPhysical = GetPhysicalHandle(drive_number, writeAccess, TRUE);
 	IFFALSE_GOTOERROR(hPhysical != INVALID_HANDLE_VALUE, "Error on acquiring disk handle.");
 
 error:
@@ -6076,7 +6076,7 @@ BOOL CEndlessUsbToolDlg::UninstallDualBoot(CEndlessUsbToolDlg *dlg)
 				goto error;
 			}
 		} else {
-			hPhysical = GetPhysicalFromDriveLetter(systemDriveLetter);
+			hPhysical = GetPhysicalFromDriveLetter(systemDriveLetter, true);
 			IFFALSE_GOTOERROR(hPhysical != INVALID_HANDLE_VALUE, "Error on acquiring disk handle.");
 
 			// remove GRUB MBR, reinstate Windows'
@@ -6087,7 +6087,7 @@ BOOL CEndlessUsbToolDlg::UninstallDualBoot(CEndlessUsbToolDlg *dlg)
 	} else { // remove EFI entry
 		bool found_boot_entry, ret;
 
-		hPhysical = GetPhysicalFromDriveLetter(systemDriveLetter);
+		hPhysical = GetPhysicalFromDriveLetter(systemDriveLetter, false);
 		IFFALSE_GOTOERROR(hPhysical != INVALID_HANDLE_VALUE, "Error on acquiring disk handle.");
 
 		ret = UninstallEndlessEFI(systemDriveLetter, hPhysical, found_boot_entry);

--- a/src/endless/EndlessUsbToolDlg.h
+++ b/src/endless/EndlessUsbToolDlg.h
@@ -435,7 +435,7 @@ private:
 	static bool IsWindowsMBR(FILE* fpDrive, const CString &TargetName);
 	static bool CanInstallToDrive(const CString &systemDriveLetter, const bool isBIOS, ErrorCause &cause);
 	static bool SetupEndlessEFI(const CString &systemDriveLetter, const CString &bootFilesPath);
-	static HANDLE GetPhysicalFromDriveLetter(const CString &driveLetter);
+	static HANDLE GetPhysicalFromDriveLetter(const CString &driveLetter, bool writeAccess);
 
 	// used by ImageUnpackCallback
 	// bled doesn't allow us to set a context variable for the callback


### PR DESCRIPTION
Two closely-related changes around opening the physical volume during dual-boot bootloader (un)installation:

* On EFI systems, don't open the device for write. We only need to read the partition table to find the ESP.
* On EFI systems, and on BIOS systems when no eosldr is present, don't lock the handle. For the former, this is again unnecessary; for the latter, it may be morally necessary, but it doesn't work (any more) on at least one system in the wild.

More details in the commit messages.

TODO:

* [x] Test EFI install & uninstall
* [x] Install on BIOS with a really old installer from before eosldr came along, then try uninstalling with this one

https://phabricator.endlessm.com/T16194
https://phabricator.endlessm.com/T26271