### PR TITLE
Add analytics for systems capable of running accelerated hypervisors

### DIFF
--- a/src/endless/Analytics.cpp
+++ b/src/endless/Analytics.cpp
@@ -296,6 +296,11 @@ void Analytics::setFirmware(const CString &firmware)
 	urlEncode(firmware, m_firmware);
 }
 
+void Analytics::setVirtualization(const CString &virtualization)
+{
+	urlEncode(virtualization, m_virtualization);
+}
+
 void Analytics::sendRequest(const CString &body, BOOL lastRequest)
 {
 	FUNCTION_ENTER;
@@ -364,4 +369,7 @@ void Analytics::prefixId(CString &id)
 
 	if (m_firmware)
 	    id.AppendFormat(L"cd5=%s&", m_firmware);
+
+	if (m_virtualization)
+	    id.AppendFormat(L"cd6=%s&", m_virtualization);
 }

--- a/src/endless/Analytics.h
+++ b/src/endless/Analytics.h
@@ -20,6 +20,7 @@ public:
 	void setLanguage(const CString &language);
 	void setManufacturerModel(const CString &manufacturer, const CString &model);
 	void setFirmware(const CString &firmware);
+	void setVirtualization(const CString &firmware);
 
 private:
 	void sendRequest(const CString &body, BOOL lastRequest = FALSE);
@@ -38,5 +39,6 @@ private:
 	CString m_model;
 	CString m_firmware;
 	CString m_windowsVersion;
+	CString m_virtualization;
 	CWinThread *m_workerThread;
 };

--- a/src/endless/EndlessUsbToolDlg.cpp
+++ b/src/endless/EndlessUsbToolDlg.cpp
@@ -897,6 +897,21 @@ BOOL CEndlessUsbToolDlg::OnInitDialog()
     auto isBIOS = IsLegacyBIOSBoot();
     Analytics::instance()->setFirmware(isBIOS ? L"BIOS" : L"EFI");
 
+    if (nWindowsVersion == WINDOWS_7)
+        Analytics::instance()->setVirtualization(L"Unknown");
+    else {
+        if (WMI::IsHyperVEnabled())
+            Analytics::instance()->setVirtualization(L"HyperV");
+        else {
+            auto vmCapable = IsProcessorFeaturePresent(PF_VIRT_FIRMWARE_ENABLED);
+
+            if (vmCapable)
+                Analytics::instance()->setVirtualization(L"Capable");
+            else
+                Analytics::instance()->setVirtualization(L"None");
+        }
+    }
+
     Analytics::instance()->startSession();
 
     if (nWindowsVersion < WINDOWS_7) {

--- a/src/endless/WMI.h
+++ b/src/endless/WMI.h
@@ -7,6 +7,7 @@
 namespace WMI {
     BOOL IsBitlockedDrive(const CString &drive);
     BOOL GetMachineInfo(CString &manufacturer, CString &model);
+    BOOL IsHyperVEnabled(void);
 
     // Adds an entry for the given bootloader to the system boot menu.
     // Supported on BIOS systems running Windows Vista or newer.


### PR DESCRIPTION
Test for vt-x/amd-v capabilities being accessible to windows, and add
this to our analytics.

This will help us determine if it's a good idea to promote virtual
machines for users that can't dual boot endless.

https://phabricator.endlessm.com/T29168