### PR TITLE
Allow failing DeletePartitions to be non-fatal

### DIFF
--- a/endless/src/endless/EndlessUsbToolDlg.cpp
+++ b/endless/src/endless/EndlessUsbToolDlg.cpp
@@ -4848,9 +4848,12 @@ DWORD WINAPI CEndlessUsbToolDlg::CreateUSBStick(LPVOID param)
 	}
 	CHECK_IF_CANCELLED;
 
-	// erase any existing partition
+	// erase any existing partition - careful here. It may be that there aren't any
+	// partitions on the device. Theoretically we know this when GetLogicalHandle fails
+	// above, but since rufus still tries DeletePartitions in its own format code, but
+	// treats the error as non-fatal, we'll follow.
 	safe_unlockclose(hPhysical);
-	IFFALSE_GOTOERROR(DeletePartitions(DriveIndex), "ErasePartitions failed");
+	IFFALSE_PRINTERROR(DeletePartitions(DriveIndex), "DeletePartitions failed");
 	hPhysical = GetPhysicalHandle(DriveIndex, TRUE, TRUE, FALSE);
 	IFFALSE_GOTOERROR(hPhysical != INVALID_HANDLE_VALUE, "Error on acquiring disk handle.");
 	RefreshDriveLayout(hPhysical);


### PR DESCRIPTION
So, you can't DeletePartitons if there aren't any, or if they're not
recognized as such by windows. This means zeroed out devices or, much
more surprisingly, devices with our iso image flashed on them, can't be
re-flashed, as our process breaks at DeletePartitons.

Stop treating that error as fatal.

Honestly, I don't know why we need to DeletePartitions before we write
zeroes over the partition table anyway, but I'm cargo culting that in
from rufus, as the author has a great deal of experience dealing with the
weird and impossible world of windows volume management.

https://phabricator.endlessm.com/T29747