### PR TITLE
Delay move from combo usb creation to cancelled until ready

### DIFF
--- a/endless/src/endless/EndlessUsbToolDlg.cpp
+++ b/endless/src/endless/EndlessUsbToolDlg.cpp
@@ -4584,7 +4584,8 @@ void CEndlessUsbToolDlg::CancelRunningOperation(bool userCancel)
 	m_cancelImageUnpack = 1;
 
     FormatStatus = FORMAT_STATUS_CANCEL;
-    if (m_currentStep != OP_FLASHING_DEVICE) {
+    if (m_currentStep != OP_FLASHING_DEVICE &&
+        m_currentStep != OP_NEW_LIVE_CREATION) {
         m_downloadManager.ClearExtraDownloadJobs(userCancel);
         PostMessage(WM_FINISHED_ALL_OPERATIONS, (WPARAM)FALSE, 0);
     }


### PR DESCRIPTION
Upstream rufus moved to a more robust method of deleting partitions,
but it's dramatically slower. We use this function in combo usb
stick creation.

There's a long standing bug in our cancel path in which the UI moves
immediately to the cancelled screen, but CreateUSBStick thread
continues until it has a chance to check for cancellation.

Now that DeletePartitions() takes about 30 seconds to complete it's
entirely possible to hit the cancel button, then hit try again,
and get far enough into a retry that the cancel status is cleared
before CreateUSBStick gets past DeletePartitions and into a
cancel check.

Hilarity ensues.

This patch makes the GUI wait until CreateUSBStick checks for
cancellation and completes before updating to the canceled screen.

https://phabricator.endlessm.com/T29693