### PR TITLE
Close handle on early return from GetDriveLabel

### DIFF
--- a/src/drive.c
+++ b/src/drive.c
@@ -958,6 +958,7 @@ BOOL GetDriveLabel(DWORD DriveIndex, char* letters, char** label)
 			wchar_to_utf8_no_alloc(VolumeName, VolumeLabel, sizeof(VolumeLabel));
 			*label = (VolumeLabel[0] != 0) ? VolumeLabel : STR_NO_LABEL;
 		}
+		safe_closehandle(h);
 		// Drive without volume assigned - always enabled
 		return TRUE;
 	}


### PR DESCRIPTION
In the case where no drive letters are assigned we leak a handle.
This causes us to fail to get another handle much later on.

https://phabricator.endlessm.com/T29949