### PR TITLE
Fix combo usb creation on older versions of windows

### DIFF
--- a/endless/src/endless/EndlessUsbToolDlg.cpp
+++ b/endless/src/endless/EndlessUsbToolDlg.cpp
@@ -5220,6 +5220,9 @@ bool CEndlessUsbToolDlg::CreatePersistentStorageFileOnexFAT(const CString& drive
         return false;
     }
 
+    // We need to keep some space free for log files, in case the user runs the installer from this device
+    bytes -= 16 * MB;
+
     tmpfile = CreateFile(storage, GENERIC_WRITE, FILE_SHARE_WRITE, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
     if (tmpfile == INVALID_HANDLE_VALUE)
         return false;
@@ -5233,7 +5236,7 @@ bool CEndlessUsbToolDlg::CreatePersistentStorageFileOnexFAT(const CString& drive
         uprintf("Failed to write marker to persistent storage file. gle=%d", GetLastError());
         return false;
     }
-    return ExtendImageFile(storage, free_bytes.QuadPart);
+    return ExtendImageFile(storage, bytes);
 }
 
 void CEndlessUsbToolDlg::ImageUnpackCallback(const uint64_t read_bytes)

--- a/endless/src/endless/EndlessUsbToolDlg.cpp
+++ b/endless/src/endless/EndlessUsbToolDlg.cpp
@@ -4796,12 +4796,12 @@ void CEndlessUsbToolDlg::SetJSONDownloadState(JSONDownloadState state)
 #define BACKUP_MBR_IMG					L"mbr.img"
 
 // Below defines need to be in this order
-#define USB_PROGRESS_UNPACK_BOOT_ZIP		2
+#define USB_PROGRESS_UNPACK_BOOT_ZIP			2
 #define USB_PROGRESS_MBR_SBR_DONE			4
-#define USB_PROGRESS_EXFAT_PREPARED			6
-#define USB_PROGRESS_ESP_PREPARED			8
-#define USB_PROGRESS_ESP_CREATION_DONE		10
-#define USB_PROGRESS_IMG_COPY_STARTED		10
+#define USB_PROGRESS_ESP_PREPARED			6
+#define USB_PROGRESS_ESP_CREATION_DONE			8
+#define USB_PROGRESS_EXFAT_PREPARED			10
+#define USB_PROGRESS_IMG_COPY_STARTED			10
 #define USB_PROGRESS_IMG_COPY_DONE			98
 #define USB_PROGRESS_ALL_DONE				100
 
@@ -4914,15 +4914,6 @@ DWORD WINAPI CEndlessUsbToolDlg::CreateUSBStick(LPVOID param)
 	UpdateProgress(OP_NEW_LIVE_CREATION, USB_PROGRESS_MBR_SBR_DONE);
 	CHECK_IF_CANCELLED;
 
-	// Format and mount exFAT
-	errorCause = ErrorCauseFormatExfatFailed;
-	IFFALSE_GOTOERROR(FormatPartition(DriveIndex, 0, EXFAT_CLUSTER_SIZE, FS_EXFAT, EXFAT_PARTITION_NAME_LIVE, FP_QUICK), "Error formatting eoslive");
-	CHECK_IF_CANCELLED;
-	errorCause = ErrorCauseMountExfatFailed;
-	IFFALSE_GOTOERROR(eosliveDriveLetter = AltMountVolume(DriveIndex, 0, FALSE), "Error mounting eoslive");
-	UpdateProgress(OP_NEW_LIVE_CREATION, USB_PROGRESS_EXFAT_PREPARED);
-	CHECK_IF_CANCELLED;
-
 	errorCause = ErrorCauseFormatESPFailed;
 
 	IFFALSE_GOTOERROR(FormatPartition(DriveIndex, partitionStart[ESP_PART_NUMBER], ESP_CLUSTER_SIZE, FS_FAT32, "", FP_QUICK), "Error formatting ESP");
@@ -4946,6 +4937,15 @@ DWORD WINAPI CEndlessUsbToolDlg::CreateUSBStick(LPVOID param)
 	espDriveLetter = "";
 
 	UpdateProgress(OP_NEW_LIVE_CREATION, USB_PROGRESS_ESP_CREATION_DONE);
+	CHECK_IF_CANCELLED;
+
+	// Format and mount exFAT
+	errorCause = ErrorCauseFormatExfatFailed;
+	IFFALSE_GOTOERROR(FormatPartition(DriveIndex, 0, EXFAT_CLUSTER_SIZE, FS_EXFAT, EXFAT_PARTITION_NAME_LIVE, FP_QUICK), "Error formatting eoslive");
+	CHECK_IF_CANCELLED;
+	errorCause = ErrorCauseMountExfatFailed;
+	IFFALSE_GOTOERROR(eosliveDriveLetter = AltMountVolume(DriveIndex, 0, FALSE), "Error mounting eoslive");
+	UpdateProgress(OP_NEW_LIVE_CREATION, USB_PROGRESS_EXFAT_PREPARED);
 	CHECK_IF_CANCELLED;
 
 	// Copy files to the exFAT partition

--- a/endless/src/endless/EndlessUsbToolDlg.cpp
+++ b/endless/src/endless/EndlessUsbToolDlg.cpp
@@ -4853,19 +4853,8 @@ DWORD WINAPI CEndlessUsbToolDlg::CreateUSBStick(LPVOID param)
 	}
 	CHECK_IF_CANCELLED;
 
-	// erase any existing partition - careful here. It may be that there aren't any
-	// partitions on the device. Theoretically we know this when GetLogicalHandle fails
-	// above, but since rufus still tries DeletePartitions in its own format code, but
-	// treats the error as non-fatal, we'll follow.
-	safe_unlockclose(hPhysical);
-	IFFALSE_PRINTERROR(DeletePartitions(DriveIndex), "DeletePartitions failed");
-	hPhysical = GetPhysicalHandle(DriveIndex, TRUE, TRUE, FALSE);
-	IFFALSE_GOTOERROR(hPhysical != INVALID_HANDLE_VALUE, "Error on acquiring disk handle.");
-	RefreshDriveLayout(hPhysical);
-
 	errorCause = ErrorCauseErasePartitionsFailed;
 	IFFALSE_GOTOERROR(ClearMBRGPT(hPhysical, SelectedDrive.DiskSize, BytesPerSector, FALSE), "ClearMBRGPT failed");
-	IFFALSE_GOTOERROR(InitializeDisk(hPhysical), "InitializeDisk failed");
 
 	// Do some preliminary setup, like calculating partition offsets, zeroing the starts of partitions
 	// so windows won't cleverly try to auto mount anything, running a more thorough GPT disk initialization

--- a/endless/src/endless/EndlessUsbToolDlg.cpp
+++ b/endless/src/endless/EndlessUsbToolDlg.cpp
@@ -5035,8 +5035,8 @@ bool CEndlessUsbToolDlg::SetupComboDisk(HANDLE hPhysical)
     // We leave the BIOS boot partition alone because windows doesn't appear to care about it anyway.
     // We try to keep going if this fails because it's not strictly necessary that it succeed.
     zeroes = (unsigned char*)calloc(BytesPerSector, 24);
-    IFFALSE_PRINTERROR(BytesPerSector * 24 == write_sectors(hPhysical, BytesPerSector, partitionStart[EXFAT_PART_NUMBER], 24, zeroes), "Unable to clear the start of eoslive.");
-    IFFALSE_PRINTERROR(BytesPerSector * 24 == write_sectors(hPhysical, BytesPerSector, partitionStart[ESP_PART_NUMBER], 24, zeroes), "Unable to clear the start of the ESP.");
+    IFFALSE_PRINTERROR(BytesPerSector * 24 == write_sectors(hPhysical, BytesPerSector, EXFAT_PART_STARTING_SECTOR, 24, zeroes), "Unable to clear the start of eoslive.");
+    IFFALSE_PRINTERROR(BytesPerSector * 24 == write_sectors(hPhysical, BytesPerSector, ESP_PART_STARTING_SECTOR, 24, zeroes), "Unable to clear the start of the ESP.");
     free(zeroes);
     RefreshDriveLayout(hPhysical);
     result = true;

--- a/endless/src/endless/EndlessUsbToolDlg.cpp
+++ b/endless/src/endless/EndlessUsbToolDlg.cpp
@@ -4952,8 +4952,10 @@ DWORD WINAPI CEndlessUsbToolDlg::CreateUSBStick(LPVOID param)
 	// Copy files to the exFAT partition
 	errorCause = ErrorCausePopulateExfatFailed;
 	IFFALSE_GOTOERROR(CopyFilesToexFAT(dlg, bootFilesPath, UTF8ToCString(eosliveDriveLetter)), "Error on CopyFilesToexFAT");
-
-	IFFALSE_PRINTERROR(CreatePersistentStorageFileOnexFAT(UTF8ToCString(eosliveDriveLetter)), "Error setting up liveUSB Persistent Storage space");
+    
+    CHECK_IF_CANCELLED;
+	
+    IFFALSE_PRINTERROR(CreatePersistentStorageFileOnexFAT(UTF8ToCString(eosliveDriveLetter)), "Error setting up liveUSB Persistent Storage space");
 
 	/* We mounted this ourselves, probably a second time, try to remove our mount. */
 	IFFALSE_PRINTERROR(AltUnmountVolume(eosliveDriveLetter, FALSE), "Failed to unmount live partition");

--- a/endless/src/endless/EndlessUsbToolDlg.cpp
+++ b/endless/src/endless/EndlessUsbToolDlg.cpp
@@ -4930,10 +4930,10 @@ DWORD WINAPI CEndlessUsbToolDlg::CreateUSBStick(LPVOID param)
 
 	// Format and mount exFAT
 	errorCause = ErrorCauseFormatExfatFailed;
-	IFFALSE_GOTOERROR(FormatPartition(DriveIndex, 0, EXFAT_CLUSTER_SIZE, FS_EXFAT, EXFAT_PARTITION_NAME_LIVE, FP_QUICK), "Error formatting eoslive");
+	IFFALSE_GOTOERROR(FormatPartition(DriveIndex, partitionStart[EXFAT_PART_NUMBER], EXFAT_CLUSTER_SIZE, FS_EXFAT, EXFAT_PARTITION_NAME_LIVE, FP_QUICK), "Error formatting eoslive");
 	CHECK_IF_CANCELLED;
 	errorCause = ErrorCauseMountExfatFailed;
-	IFFALSE_GOTOERROR(eosliveDriveLetter = AltMountVolume(DriveIndex, 0, FALSE), "Error mounting eoslive");
+	IFFALSE_GOTOERROR(eosliveDriveLetter = AltMountVolume(DriveIndex, partitionStart[EXFAT_PART_NUMBER], FALSE), "Error mounting eoslive");
 	UpdateProgress(OP_NEW_LIVE_CREATION, USB_PROGRESS_EXFAT_PREPARED);
 	CHECK_IF_CANCELLED;
 

--- a/endless/src/endless/EndlessUsbToolDlg.cpp
+++ b/endless/src/endless/EndlessUsbToolDlg.cpp
@@ -39,6 +39,7 @@ extern "C" {
 #include "mbr_grub2.h"
 
 LONGLONG CEndlessUsbToolDlg::partitionStart[EXPECTED_NUMBER_OF_PARTITIONS];
+GUID CEndlessUsbToolDlg::DiskGUID;
 
 BOOL its_a_me_mario = FALSE;
 
@@ -5033,7 +5034,8 @@ bool CEndlessUsbToolDlg::SetupComboDisk(HANDLE hPhysical)
     // In any event, if we do this again here, and fill in DiskId and MaxPartitionCount, as rufus does, we
     // succeed under windows 7 and 8.1.
     size = sizeof(CreateDisk);
-    IGNORE_RETVAL(CoCreateGuid(&CreateDisk.Gpt.DiskId));
+    IGNORE_RETVAL(CoCreateGuid(&DiskGUID));
+    CreateDisk.Gpt.DiskId = DiskGUID;
     CreateDisk.Gpt.MaxPartitionCount = MAX_PARTITIONS;
     IFFALSE_GOTOERROR(DeviceIoControl(hPhysical, IOCTL_DISK_CREATE_DISK, (BYTE*)&CreateDisk, size, NULL, 0, &size, NULL), "Unable to initialize GPT disk structures");
 
@@ -5074,7 +5076,8 @@ bool CEndlessUsbToolDlg::CreateUSBPartitionLayout(HANDLE hPhysical)
 
 	DriveLayout->PartitionStyle = PARTITION_STYLE_GPT;
 	DriveLayout->PartitionCount = EXPECTED_NUMBER_OF_PARTITIONS;
-	IGNORE_RETVAL(CoCreateGuid(&DriveLayout->Gpt.DiskId));
+	// DiskGUID is set up in SetupComboDisk
+	DriveLayout->Gpt.DiskId = DiskGUID;
 
 	LONGLONG partitionSize[EXPECTED_NUMBER_OF_PARTITIONS] = {
 		// there is a 2nd copy of the GPT at the end of the disk so we

--- a/endless/src/endless/EndlessUsbToolDlg.h
+++ b/endless/src/endless/EndlessUsbToolDlg.h
@@ -315,6 +315,7 @@ private:
 
 	std::unique_ptr<EosldrInstaller> m_eosldrInstaller;
 
+	static GUID DiskGUID;
 	static LONGLONG partitionStart[EXPECTED_NUMBER_OF_PARTITIONS];
 
 	void TrackEvent(const CString &action, const CString &label = CString(), LONGLONG value = -1L);

--- a/endless/src/endless/EndlessUsbToolDlg.h
+++ b/endless/src/endless/EndlessUsbToolDlg.h
@@ -414,7 +414,7 @@ private:
 
 	static DWORD WINAPI CreateUSBStick(LPVOID param);
 	static bool DeleteMountpointsForDrive(DWORD DriveIndex);
-	static bool CreateUSBPartitionLayout(HANDLE hPhysical, DWORD &BytesPerSector);
+	static bool CreateUSBPartitionLayout(HANDLE hPhysical);
 
 	static bool UnpackZip(const CComBSTR source, const CComBSTR dest);
 	static void RemoveNonEmptyDirectory(const CString directoryPath);
@@ -424,7 +424,7 @@ private:
 	static bool CopyFilesToexFAT(CEndlessUsbToolDlg *dlg, const CString &fromFolder, const CString &driveLetter);
 	static bool CreatePersistentStorageFileOnexFAT(const CString& drive);
 	static bool WriteMBRToUSB(HANDLE hPhysical, const CString &bootFilesPath);
-	static bool WriteBIOSBootPartitionToUSB(HANDLE hPhysical, const CString &bootFilesPath, DWORD bytesPerSector);
+	static bool WriteBIOSBootPartitionToUSB(HANDLE hPhysical, const CString &bootFilesPath);
 
 	static DWORD WINAPI SetupDualBoot(LPVOID param);
 	static bool SetupDualBootFiles(CEndlessUsbToolDlg *dlg, const CString &systemDriveLetter, const CString &bootFilesPath, ErrorCause &errorCause);

--- a/endless/src/endless/EndlessUsbToolDlg.h
+++ b/endless/src/endless/EndlessUsbToolDlg.h
@@ -414,6 +414,7 @@ private:
 
 	static DWORD WINAPI CreateUSBStick(LPVOID param);
 	static bool DeleteMountpointsForDrive(DWORD DriveIndex);
+	static bool SetupComboDisk(HANDLE hPhysical);
 	static bool CreateUSBPartitionLayout(HANDLE hPhysical);
 
 	static bool UnpackZip(const CComBSTR source, const CComBSTR dest);

--- a/endless/src/endless/EndlessUsbToolDlg.h
+++ b/endless/src/endless/EndlessUsbToolDlg.h
@@ -114,6 +114,11 @@ enum CompressionType {
     CompressionTypeSquash,
 };
 
+enum CreatePartitionMode {
+    JUST_ESP,
+    ALL_PARTITIONS
+};
+
 struct SignedFile_t {
     SignedFile_t(const CString &filePath_, ULONGLONG fileSize_, const CString &sigPath_)
         :
@@ -416,7 +421,7 @@ private:
 	static DWORD WINAPI CreateUSBStick(LPVOID param);
 	static bool DeleteMountpointsForDrive(DWORD DriveIndex);
 	static bool SetupComboDisk(HANDLE hPhysical);
-	static bool CreateUSBPartitionLayout(HANDLE hPhysical);
+	static bool CreateUSBPartitionLayout(HANDLE hPhysical, enum CreatePartitionMode mode);
 
 	static bool UnpackZip(const CComBSTR source, const CComBSTR dest);
 	static void RemoveNonEmptyDirectory(const CString directoryPath);


### PR DESCRIPTION
Windows 7 and 8 combo USB stick creation currently fails because windows 7 and 8 have trouble
with multiple partitions on USB sticks. We work around this by partitioning the device in multiple
steps, so we only need to access the first partition at any time.

https://phabricator.endlessm.com/T29949