### PR TITLE
Update Endless company name in various places

### DIFF
--- a/endless/src/endless/EndlessUsbTool.rc
+++ b/endless/src/endless/EndlessUsbTool.rc
@@ -186,11 +186,11 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "CompanyName", "Endless Mobile"
+            VALUE "CompanyName", "Endless OS Foundation LLC"
             VALUE "FileDescription", "Endless Installer"
             VALUE "FileVersion", RELEASE_VER_STR "\0"
             VALUE "InternalName", "endless-installer.exe"
-            VALUE "LegalCopyright", "Endless Mobile, Inc."
+            VALUE "LegalCopyright", "Endless OS Foundation LLC"
             VALUE "OriginalFilename", "endless-installer.exe"
             VALUE "ProductName", "Endless Installer"
             VALUE "ProductVersion", RELEASE_VER_STR "\0"

--- a/endless/src/endless/EndlessUsbToolDlg.cpp
+++ b/endless/src/endless/EndlessUsbToolDlg.cpp
@@ -393,7 +393,7 @@ const wchar_t* mainWindowTitle = L"Endless Installer";
 
 #define REGKEY_DISPLAYNAME_TEXT	ENDLESS_OS_NAME
 #define REGKEY_HELP_LINK_TEXT	_T(COMMUNITY_URL)
-#define REGKEY_PUBLISHER_TEXT	L"Endless Mobile, Inc."
+#define REGKEY_PUBLISHER_TEXT	L"Endless OS Foundation LLC"
 #pragma endregion Uninstall_registry_stuff
 
 static LPCTSTR OperationToStr(int op)


### PR DESCRIPTION
On April 1st 2020, this application was transferred from Endless Mobile,
Inc. to Endless OS Foundation LLC.

I believe the strings in the .rc file are used in the Properties
dialog for the file in Windows Explorer. REGKEY_PUBLISHER_TEXT is used
when adding an entry to Change or Remove Programs to allow Endless OS to
be uninstalled from there.